### PR TITLE
DO NOT MERGE VerifyUpgrade

### DIFF
--- a/files.go
+++ b/files.go
@@ -61,3 +61,15 @@ func ensureFolderExists(t *testing.T, dir string) {
 		require.NoError(t, err)
 	}
 }
+
+func findFiles(t *testing.T, dir string, matches func(string) bool) []string {
+	var files []string
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if matches(path) {
+			files = append(files, path)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return files
+}

--- a/files.go
+++ b/files.go
@@ -1,0 +1,63 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providertest
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func dirExists(t *testing.T, dir string) bool {
+	_, err := os.Stat(dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false
+		}
+		require.NoError(t, err)
+	}
+	return true
+}
+
+func deleteFileIfExists(t *testing.T, file string) {
+	err := os.Remove(file)
+	if errors.Is(err, fs.ErrNotExist) {
+		return
+	}
+	require.NoError(t, err)
+}
+
+func writeFile(t *testing.T, file string, data []byte) {
+	ensureFolderExists(t, filepath.Dir(file))
+	err := os.WriteFile(file, data, 0755)
+	require.NoError(t, err)
+}
+
+func readFile(t *testing.T, file string) string {
+	bytes, err := os.ReadFile(file)
+	require.NoError(t, err)
+	return string(bytes)
+}
+
+func ensureFolderExists(t *testing.T, dir string) {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		err = os.MkdirAll(dir, 0755)
+		require.NoError(t, err)
+	}
+}

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -16,67 +16,119 @@ package flags
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	"sort"
 	"strings"
 )
+
+var (
+	testModeEnvVarName          = "PULUMI_PROVIDER_TEST_MODE"
+	testModeEnv, testModeEnvSet = os.LookupEnv(testModeEnvVarName)
+)
+
+type Flag interface {
+	IsSet() bool
+
+	// Explains why the flag is considered to be IsSet().
+	WhySet() string
+
+	// Explains why the flag is not considered to be IsSet().
+	WhyNotSet() string
+}
+
+type stdFlag struct {
+	flag     string
+	flagVal  *bool
+	modeName string
+}
+
+func newFlag(modeName, description string) *stdFlag {
+	fl := fmt.Sprintf("provider-%s", modeName)
+	return &stdFlag{
+		flag:     fl,
+		modeName: modeName,
+		flagVal:  flag.Bool(fl, false, description),
+	}
+}
+
+func (f *stdFlag) IsSet() bool {
+	return f.WhySet() != ""
+}
 
 // Environment variables override flags.
 // Flags are prefixed `-provider-`
 // Environment variable can have multiple modes set e.g.
 // PULUMI_PROVIDER_TEST_MODE=e2e,sdk-python
 // PULUMI_PROVIDER_TEST_MODE=skip-e2e
-func parseFlag(modeName string, flagVal *bool) bool {
-	env, ok := os.LookupEnv("PULUMI_PROVIDER_TEST_MODE")
-	if ok {
-		modes := strings.Split(env, ",")
+func (f *stdFlag) WhySet() string {
+	if testModeEnvSet {
+		modes := strings.Split(testModeEnv, ",")
 		for _, mode := range modes {
-			if mode == modeName {
-				return true
+			if mode == f.modeName {
+				return fmt.Sprintf("%s=%q contains %q",
+					testModeEnvVarName, testModeEnv, f.modeName)
 			}
 		}
 	}
-	return flagVal != nil && *flagVal
+	if f.flagVal != nil && *f.flagVal {
+		return fmt.Sprintf("-%s flag was set", f.flag)
+	}
+	return ""
+}
+
+func (f *stdFlag) WhyNotSet() string {
+	if f.IsSet() {
+		return ""
+	}
+	var reasons []string
+	reasons = append(reasons, fmt.Sprintf("-%s flag is unset", f.flag))
+	if testModeEnvSet {
+		reasons = append(reasons, fmt.Sprintf("%s=%q does not contain %q",
+			testModeEnvVarName, testModeEnv, f.modeName))
+	} else {
+		reasons = append(reasons, fmt.Sprintf("%s=%q is unset",
+			testModeEnvVarName, f.modeName))
+	}
+	return strings.Join(reasons, " and ")
+}
+
+type orFlag struct {
+	a Flag
+	b Flag
+}
+
+func (f *orFlag) IsSet() bool {
+	return f.WhySet() != ""
+}
+
+func (f *orFlag) WhySet() string {
+	if reason := f.a.WhySet(); reason != "" {
+		return reason
+	}
+	if reason := f.b.WhySet(); reason != "" {
+		return reason
+	}
+	return ""
+}
+
+func (f *orFlag) WhyNotSet() string {
+	if f.IsSet() {
+		return ""
+	}
+	mixed := fmt.Sprintf("%s and %s", f.a.WhyNotSet(), f.b.WhyNotSet())
+	parts := strings.Split(mixed, " and ")
+	sort.Strings(parts)
+	return fmt.Sprintf("\n%s", strings.Join(parts, "\n"))
 }
 
 var (
-	skipE2e       = flag.Bool("provider-skip-e2e", false, "Skip e2e provider tests")
-	e2e           = flag.Bool("provider-e2e", false, "Enable full e2e provider tests, otherwise uses quick mode by default")
-	sdk           = flag.Bool("provider-sdk", false, "Enable all SDK provider tests")
-	sdkCsharp     = flag.Bool("provider-sdk-csharp", false, "Enable C# SDK provider tests")
-	sdkGo         = flag.Bool("provider-sdk-go", false, "Enable Go SDK provider tests")
-	sdkPython     = flag.Bool("provider-sdk-python", false, "Enable Python SDK provider tests")
-	sdkTypescript = flag.Bool("provider-sdk-typescript", false, "Enable TypeScript SDK provider tests")
-	snapshot      = flag.Bool("provider-snapshot", false, "Create snapshots for use with quick e2e tests")
+	SkipE2e       = newFlag("skip-e2e", "Skip e2e provider tests")
+	E2e           = newFlag("e2e", "Enable full e2e provider tests, otherwise uses quick mode by default")
+	Sdk           = newFlag("sdk", "Enable all SDK provider tests")
+	SdkCsharp     = &orFlag{newFlag("sdk-csharp", "Enable C# SDK provider tests"), Sdk}
+	SdkGo         = &orFlag{newFlag("sdk-go", "Enable Go SDK provider tests"), Sdk}
+	SdkPython     = &orFlag{newFlag("sdk-python", "Enable Python SDK provider tests"), Sdk}
+	SdkTypescript = &orFlag{newFlag("sdk-typescript", "Enable TypeScript SDK provider tests"), Sdk}
+	Snapshot      = newFlag("snapshot", "Create snapshots for use with quick e2e tests")
 )
-
-func SkipE2e() bool {
-	return parseFlag("skip-e2e", skipE2e)
-}
-
-func IsE2e() bool {
-	return parseFlag("e2e", e2e)
-}
-
-func IsSdkAll() bool {
-	return parseFlag("sdk", sdk)
-}
-
-func IsSdkCsharp() bool {
-	return parseFlag("sdk-csharp", sdkCsharp) || IsSdkAll()
-}
-
-func IsSdkGo() bool {
-	return parseFlag("sdk-go", sdkGo) || IsSdkAll()
-}
-
-func IsSdkPython() bool {
-	return parseFlag("sdk-python", sdkPython) || IsSdkAll()
-}
-
-func IsSdkTypescript() bool {
-	return parseFlag("sdk-typescript", sdkTypescript) || IsSdkAll()
-}
-
-func IsSnapshot() bool {
-	return parseFlag("snapshot", snapshot)
-}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,12 @@ module github.com/pulumi/providertest
 go 1.21.0
 
 require (
+	github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1
 	github.com/pulumi/pulumi/pkg/v3 v3.86.0
 	github.com/pulumi/pulumi/sdk/v3 v3.86.0
+	github.com/stretchr/testify v1.8.3
+	google.golang.org/protobuf v1.31.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -170,7 +174,6 @@ require (
 	github.com/skeema/knownhosts v1.1.0 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.8.3 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
@@ -200,7 +203,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20230706204954-ccb25ca9f130 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
 	google.golang.org/grpc v1.57.0 // indirect
-	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1464,6 +1464,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/prometheus v0.35.0/go.mod h1:7HaLx5kEPKJ0GDgbODG0fZgXbQ8K/XjZNJXQmbmgQlY=
 github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGOON44WyAp4Xqbbk=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1 h1:SCg1gjfY9N4yn8U8peIUYATifjoDABkyR7H9lmefsfc=
+github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1/go.mod h1:7OeUPH8rpt5ipyj9EFcnXpuzQ8SHL0dyqdfa8nOacdk=
 github.com/pulumi/pulumi/pkg/v3 v3.86.0 h1:G4spuT89ZN8lSxT9WkMF/JaP7n+wu7ubEly7Yy8uza0=
 github.com/pulumi/pulumi/pkg/v3 v3.86.0/go.mod h1:Qs55gPhUwM/Dua3VRtHXLLlpY8uEe+llDBIZc+1pvHM=
 github.com/pulumi/pulumi/sdk/v3 v3.86.0 h1:Cxg0rGdvMt9GqGvesFTj8+WaO/ihmALYlQf4zm1GzFw=

--- a/programtest.go
+++ b/programtest.go
@@ -1,0 +1,78 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providertest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+)
+
+// Code in this file is copied from the ProgramTest framework and modified to introduce
+// extensibility points. It should eventually be upstreamed ideally so this is not needed here.
+type programTestWrapper struct {
+	pt *integration.ProgramTester
+}
+
+// Behaves just like ProgramTester.TestLifeCycleInitAndDestroy() but with custom inner test logic.
+// This function was obtained by inlining TestLifeCycleInitAndDestroy implementation and
+// generalizing it.
+func (wrapper *programTestWrapper) lifecycleInitAndDestroy(
+	t *testing.T,
+	opts integration.ProgramTestOptions,
+	customTest func() error,
+) error {
+	pt := wrapper.pt
+	assert.Falsef(t, opts.RunUpdateTest, "RunUpdateTest is not supported")
+
+	err := pt.TestLifeCyclePrepare()
+	if err != nil {
+		return fmt.Errorf("copying test to temp dir %s: %w", "<tmpdir>", err)
+	}
+
+	pt.TestFinished = false
+	if opts.DestroyOnCleanup {
+		t.Cleanup(pt.TestCleanUp)
+	} else {
+		defer pt.TestCleanUp()
+	}
+
+	err = pt.TestLifeCycleInitialize()
+	if err != nil {
+		return fmt.Errorf("initializing test project: %w", err)
+	}
+
+	destroyStack := func() {
+		destroyErr := pt.TestLifeCycleDestroy()
+		assert.NoError(t, destroyErr)
+	}
+	if opts.DestroyOnCleanup {
+		// Allow other tests to refer to this stack until the test is complete.
+		t.Cleanup(destroyStack)
+	} else {
+		// Ensure that before we exit, we attempt to destroy and remove the stack.
+		defer destroyStack()
+	}
+
+	if err = customTest(); err != nil {
+		return err
+	}
+
+	pt.TestFinished = true
+	return nil
+}

--- a/providertest.go
+++ b/providertest.go
@@ -181,6 +181,12 @@ func (pt *ProviderTest) Run(t *testing.T) {
 		}
 		pt.RunSdk(t, "typescript")
 	})
+	for _, m := range UpgradeTestModes() {
+		t.Run(fmt.Sprintf("upgrade-%s", m), func(t *testing.T) {
+			t.Helper()
+			pt.VerifyUpgrade(t, m)
+		})
+	}
 }
 
 func StartProviders(ctx context.Context, providerStartups ...StartProvider) ([]*ProviderAttach, error) {

--- a/providertest.go
+++ b/providertest.go
@@ -131,19 +131,19 @@ func (pt *ProviderTest) Run(t *testing.T) {
 	t.Helper()
 	t.Run("e2e", func(t *testing.T) {
 		t.Helper()
-		if flags.SkipE2e() {
-			t.Skip("Skipping e2e tests due to either -provider-skip-e2e or PULUMI_PROVIDER_TEST_MODE=skip-e2e being set")
+		if flags.SkipE2e.IsSet() {
+			t.Skipf("Skipping e2e tests because %s", flags.SkipE2e.WhySet())
 			return
 		}
-		pt.RunE2e(t, flags.IsE2e(), pt.e2eOptions...)
+		pt.RunE2e(t, flags.E2e.IsSet(), pt.e2eOptions...)
 	})
 	t.Run("sdk-csharp", func(t *testing.T) {
 		t.Helper()
 		if reason, skip := pt.skipSdk["csharp"]; skip {
 			t.Skip(reason...)
 		}
-		if !flags.IsSdkCsharp() {
-			t.Skip("Skipping C# SDK tests due to neither -provider-sdk-csharp nor PULUMI_PROVIDER_TEST_MODE=sdk-csharp being set")
+		if !flags.SdkCsharp.IsSet() {
+			t.Skipf("Skipping C# SDK tests because %s", flags.SdkCsharp.WhyNotSet())
 			return
 		}
 		pt.RunSdk(t, "csharp")
@@ -153,8 +153,8 @@ func (pt *ProviderTest) Run(t *testing.T) {
 		if reason, skip := pt.skipSdk["go"]; skip {
 			t.Skip(reason...)
 		}
-		if !flags.IsSdkGo() {
-			t.Skip("Skipping Go SDK tests due to neither -provider-sdk-go nor PULUMI_PROVIDER_TEST_MODE=sdk-go being set")
+		if !flags.SdkGo.IsSet() {
+			t.Skipf("Skipping Go SDK tests because %s", flags.SdkGo.WhyNotSet())
 			return
 		}
 		pt.RunSdk(t, "go")
@@ -164,8 +164,8 @@ func (pt *ProviderTest) Run(t *testing.T) {
 		if reason, skip := pt.skipSdk["python"]; skip {
 			t.Skip(reason...)
 		}
-		if !flags.IsSdkPython() {
-			t.Skip("Skipping Python SDK tests due to neither -provider-sdk-python nor PULUMI_PROVIDER_TEST_MODE=sdk-python being set")
+		if !flags.SdkPython.IsSet() {
+			t.Skipf("Skipping Python SDK tests because %s", flags.SdkPython.WhyNotSet())
 			return
 		}
 		pt.RunSdk(t, "python")
@@ -175,8 +175,8 @@ func (pt *ProviderTest) Run(t *testing.T) {
 		if reason, skip := pt.skipSdk["typescript"]; skip {
 			t.Skip(reason...)
 		}
-		if !flags.IsSdkPython() {
-			t.Skip("Skipping Typescript SDK tests due to neither -provider-sdk-typescript nor PULUMI_PROVIDER_TEST_MODE=sdk-typescript being set")
+		if !flags.SdkTypescript.IsSet() {
+			t.Skipf("Skipping Typescript SDK tests because %s", flags.SdkTypescript.WhyNotSet())
 			return
 		}
 		pt.RunSdk(t, "typescript")

--- a/providertest.go
+++ b/providertest.go
@@ -31,6 +31,7 @@ type ProviderTest struct {
 	config           map[string]string
 	e2eOptions       []E2eOption
 	skipSdk          map[string][]any
+	upgradeOpts      providerUpgradeOpts
 }
 
 // NewProviderTest creates a new provider test with the initial directory to be tested.

--- a/upgrade.go
+++ b/upgrade.go
@@ -70,6 +70,7 @@ type providerUpgradeBuilder struct {
 	program                string
 	modes                  map[UpgradeTestMode]string // skip reason by mode
 	baselineVersion        string
+	config                 map[string]string
 }
 
 func (b *providerUpgradeBuilder) Skip(
@@ -83,6 +84,11 @@ func (b *providerUpgradeBuilder) Skip(
 
 func (b *providerUpgradeBuilder) WithBaselineVersion(v string) *providerUpgradeBuilder {
 	b.baselineVersion = v
+	return b
+}
+
+func (b *providerUpgradeBuilder) WithConfig(key, value string) *providerUpgradeBuilder {
+	b.config[key] = value
 	return b
 }
 
@@ -289,8 +295,9 @@ func (b *providerUpgradeBuilder) checkProviderUpgradePreviewOnly(t *testing.T) {
 	t.Logf("Baseline provider version: %s", b.baselineVersion)
 
 	opts := integration.ProgramTestOptions{
-		Dir: b.program,
-		Env: []string{},
+		Dir:    b.program,
+		Env:    []string{},
+		Config: b.config,
 
 		// Skips are required by programTestHelper.previewOnlyUpgradeTest
 		SkipUpdate:       true,
@@ -469,6 +476,7 @@ func (b *providerUpgradeBuilder) providerUpgradeRecordBaselines(t *testing.T) {
 			writeFile(t, info.stateFile, state)
 			t.Logf("wrote %s", info.stateFile)
 		},
+		Config: b.config,
 
 		// TODO eks.Cluster fails refresh on 5.42.0
 		SkipRefresh: true,

--- a/upgrade.go
+++ b/upgrade.go
@@ -60,6 +60,7 @@ func VerifyUpgrade(t *testing.T) *providerUpgradeBuilder {
 			UpgradeTestMode_Quick:       "",
 			UpgradeTestMode_PreviewOnly: "",
 		},
+		config: map[string]string{},
 	}
 }
 

--- a/upgrade.go
+++ b/upgrade.go
@@ -587,8 +587,9 @@ func (b *providerUpgradeBuilder) providerUpgradeRecordBaselines(t *testing.T) {
 			t.Logf("wrote %s", info.stateFile)
 		},
 		Config: b.config,
-
-		// TODO eks.Cluster fails refresh on 5.42.0
+		// We could record Refresh for posterity but it is not strictly needed for upgrade
+		// tests only. It would be needed for tests that try to use snapshots to inform
+		// import or refresh testing.
 		SkipRefresh: true,
 	}
 	integration.ProgramTest(t, &test)

--- a/upgrade.go
+++ b/upgrade.go
@@ -184,6 +184,7 @@ func WithProviderName(name string) Option {
 	return func(b *ProviderTest) { b.upgradeOpts.providerName = name }
 }
 
+// TODO[pulumi/providertest#9] make this redundant.
 func WithResourceProviderServer(s pulumirpc.ResourceProviderServer) Option {
 	contract.Assertf(s != nil, "ResourceProviderServer cannot be nil")
 	return func(b *ProviderTest) { b.upgradeOpts.resourceProviderServer = s }

--- a/upgrade.go
+++ b/upgrade.go
@@ -1,0 +1,500 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providertest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	jsonpb "google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	testutils "github.com/pulumi/pulumi-terraform-bridge/testing/x"
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+type UpgradeTestMode int
+
+const (
+	UpgradeTestMode_Quick UpgradeTestMode = iota
+	UpgradeTestMode_PreviewOnly
+)
+
+func (m UpgradeTestMode) String() string {
+	switch m {
+	case UpgradeTestMode_PreviewOnly:
+		return "PreviewOnly"
+	case UpgradeTestMode_Quick:
+		return "Quick"
+	}
+	return "<unknown>"
+}
+
+func VerifyUpgrade(t *testing.T) *providerUpgradeBuilder {
+	return &providerUpgradeBuilder{
+		tt: t,
+		modes: map[UpgradeTestMode]string{
+			UpgradeTestMode_Quick:       "",
+			UpgradeTestMode_PreviewOnly: "",
+		},
+	}
+}
+
+type providerUpgradeBuilder struct {
+	tt                     *testing.T
+	resourceProviderServer pulumirpc.ResourceProviderServer
+	name                   string
+	program                string
+	modes                  map[UpgradeTestMode]string // skip reason by mode
+}
+
+func (b *providerUpgradeBuilder) Skip(
+	m UpgradeTestMode,
+	reason string,
+) *providerUpgradeBuilder {
+	require.NotEmpty(b.tt, reason, "reason cannot be empty")
+	b.modes[m] = reason
+	return b
+}
+
+func (b *providerUpgradeBuilder) WithProgram(dir string) *providerUpgradeBuilder {
+	require.NotEmptyf(b.tt, dir, "dir cannot be empty")
+	require.Truef(b.tt, dirExists(b.tt, dir), "no such directory")
+	b.program = dir
+	return b
+}
+
+func (b *providerUpgradeBuilder) WithProviderName(name string) *providerUpgradeBuilder {
+	require.NotEmptyf(b.tt, name, "name cannot be empty, "+
+		"expecting a provider name like `gcp` or `aws`")
+	b.name = name
+	return b
+}
+
+func (b *providerUpgradeBuilder) WithResourceProviderServer(
+	s pulumirpc.ResourceProviderServer,
+) *providerUpgradeBuilder {
+	require.NotNil(b.tt, s)
+	b.resourceProviderServer = s
+	return b
+}
+
+func (b *providerUpgradeBuilder) Run() {
+	require.NotEmptyf(b.tt, b.program, "WithProgram call is required")
+
+	acceptEnvVar := "PULUMI_ACCEPT"
+	accept := cmdutil.IsTruthy(os.Getenv(acceptEnvVar))
+	if accept {
+		b.tt.Logf("Running to ProgramTest re-record baseline behavior as requested by "+
+			"setting %q environment variable", acceptEnvVar)
+		b.providerUpgradeRecordBaselines(b.tt)
+	}
+	b.tt.Run("Quick", func(t *testing.T) {
+		if skip := b.modes[UpgradeTestMode_Quick]; skip != "" {
+			t.Skip(skip)
+		}
+		b.checkProviderUpgradeQuick(t)
+	})
+	b.tt.Run("PreviewOnly", func(t *testing.T) {
+		if skip := b.modes[UpgradeTestMode_PreviewOnly]; skip != "" {
+			t.Skip(skip)
+		}
+		if testing.Short() {
+			t.Skipf("Skipping in -short mode")
+			return
+		}
+
+		if accept {
+			t.Skipf("Skipping because baselines were just pre-recorded")
+		} else {
+			b.checkProviderUpgradePreviewOnly(t)
+		}
+	})
+}
+
+func (b *providerUpgradeBuilder) checkProviderUpgradeQuick(t *testing.T) {
+	require.NotNilf(b.tt, b.resourceProviderServer, "WithResourceProviderServer is required")
+	info := b.newProviderUpgradeInfo(t)
+
+	bytes, err := os.ReadFile(info.grpcFile)
+	require.NoErrorf(t, err,
+		"No pre-recorded gRPC log found, try to run TestProviderUpgradeRecord")
+
+	eng := &mockPulumiEngine{
+		provider:              b.resourceProviderServer,
+		lastCheckRequestByURN: map[string]*pulumirpc.CheckRequest{},
+	}
+
+	for _, line := range strings.Split(string(bytes), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		line = ignoreStables(t, line)
+		eng.replayGRPCLog(t, line)
+	}
+	require.NotEmptyf(t, eng.verifiedDiffResourceCounter, "Need at least one replay test")
+}
+
+// Verifies provider upgrades by replaying Diff calls. This is slighly involved. The available
+// information is Check and Diff calls recorded on vPrev version of the provider, and a vNext
+// in-memory version of the provider available to test. The calls cannot be replayed directly,
+// instead Check and Diff calls are paired to do something equivalent to this:
+//
+//	rawInputs := vPrev.Check.inputs
+//	diffNew := vNext.Diff(vPrev.State, vNext.Check(rawInputs))
+//	diffOld := vPrev.Diff(vPrev.State, vPrev.Check(rawInputs))
+//	assert.Equal(t, diffOld, diffNew)
+//
+// Essentially the pre-recorded Check calls are used to extract a gRPC representation of raw
+// resource inputs coming from the user program. This could have been parsed from YAML programs but
+// would require interpolating variables and converting to gRPC-compatible form, parsing Check is
+// easier.
+//
+// Then it is asserted that the vNext version of Diff behaves consistently with the vPrev.Diff on
+// old state and inputs. This simulates the scenario of updating the provider while not making any
+// changes to the program.
+type mockPulumiEngine struct {
+	// vNext in-memory provider
+	provider                    pulumirpc.ResourceProviderServer
+	lastCheckRequestByURN       map[string]*pulumirpc.CheckRequest
+	verifiedDiffResourceCounter int
+}
+
+func (e *mockPulumiEngine) replayGRPCLog(t *testing.T, jsonLog string) {
+	var entry jsonLogEntry
+	err := json.Unmarshal([]byte(jsonLog), &entry)
+	require.NoError(t, err)
+
+	switch entry.Method {
+	case "/pulumirpc.ResourceProvider/Check":
+		req := unmarshalProto(t, entry.Request, new(pulumirpc.CheckRequest))
+		e.recordCheck(t, req)
+	case "/pulumirpc.ResourceProvider/Diff":
+		req := unmarshalProto(t, entry.Request, new(pulumirpc.DiffRequest))
+		e.fixupDiff(t, req)
+		entry.Request = marshalProto(t, req)
+		b, err := json.Marshal(entry)
+		require.NoError(t, err)
+		testutils.Replay(t, e.provider, string(b))
+		e.verifiedDiffResourceCounter++
+		t.Logf("Replayed Diff on %v", req.Urn)
+	}
+}
+
+func (e *mockPulumiEngine) recordCheck(t *testing.T, checkReq *pulumirpc.CheckRequest) {
+	e.lastCheckRequestByURN[checkReq.Urn] = checkReq
+}
+
+func (e *mockPulumiEngine) fixupDiff(t *testing.T, diffReq *pulumirpc.DiffRequest) {
+	ctx := context.Background()
+	lastCheck, ok := e.lastCheckRequestByURN[diffReq.Urn]
+	require.Truef(t, ok, "Diff called for %q but there is no recent Check for this URN",
+		diffReq.Urn)
+
+	// Assuming here that CheckRequest does not depend on the provider version, so that
+	// replaying a pre-recorded Check request from old provider on the new RC provider is
+	// reasonable.
+	checkResp, err := e.provider.Check(ctx, lastCheck)
+	require.NoError(t, err)
+
+	// Emulate the real engine would be passing checked inputs into the News field of the
+	// DiffRequest and then replay this updated request against the provider.
+	diffReq.News = checkResp.GetInputs()
+}
+
+type jsonLogEntry struct {
+	Method   string          `json:"method"`
+	Request  json.RawMessage `json:"request,omitempty"`
+	Response json.RawMessage `json:"response,omitempty"`
+}
+
+func unmarshalProto[T protoreflect.ProtoMessage](t *testing.T, data json.RawMessage, req T) T {
+	err := jsonpb.Unmarshal([]byte(data), req)
+	require.NoError(t, err)
+	return req
+}
+
+func marshalProto[T protoreflect.ProtoMessage](t *testing.T, req T) json.RawMessage {
+	bytes, err := jsonpb.Marshal(req)
+	require.NoError(t, err)
+	return bytes
+}
+
+func ignoreStables(t *testing.T, grpcLogEntry string) string {
+	var v map[string]any
+	err := json.Unmarshal([]byte(grpcLogEntry), &v)
+	require.NoError(t, err)
+	if r, ok := v["response"]; ok {
+		r := r.(map[string]any)
+		if _, ok := r["stables"]; ok {
+			r["stables"] = "*"
+		}
+	}
+	out, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(out)
+}
+
+type providerUpgradeInfo struct {
+	testCaseDir             string
+	recordingDir            string
+	baselineProviderVersion string
+	grpcFile                string
+	stateFile               string
+	opts                    integration.ProgramTestOptions
+}
+
+func (b *providerUpgradeBuilder) newProviderUpgradeInfo(t *testing.T) providerUpgradeInfo {
+	info := providerUpgradeInfo{}
+	info.testCaseDir = filepath.Join("testdata", "resources")
+	pyaml := filepath.Join(b.program, "Pulumi.yaml")
+	v := parseProviderVersion(t, pyaml)
+	info.baselineProviderVersion = v
+	info.recordingDir = filepath.Join("testdata", "recorded", v, "resources")
+	var err error
+	info.grpcFile, err = filepath.Abs(filepath.Join(info.recordingDir, "grpc.json"))
+	require.NoError(t, err)
+	info.stateFile, err = filepath.Abs(filepath.Join(info.recordingDir, "state.json"))
+	require.NoError(t, err)
+	info.opts = integration.ProgramTestOptions{
+		Dir: info.testCaseDir,
+	}
+	return info
+}
+
+func parseProviderVersion(t *testing.T, yamlFile string) string {
+	type model struct {
+		Resources struct {
+			Provider struct {
+				Options struct {
+					Version string `yaml:"version"`
+				} `yaml:"options"`
+			} `yaml:"provider"`
+		} `json:"resources"`
+	}
+	bytes, err := os.ReadFile(yamlFile)
+	require.NoError(t, err)
+	var m model
+	yaml.Unmarshal(bytes, &m)
+	require.NoError(t, err)
+	v := m.Resources.Provider.Options.Version
+	require.NotEmptyf(t, v, "Failed to parse Pulumi.yaml: "+
+		"resources.provider.options.version is empty")
+	return v
+}
+
+func (b *providerUpgradeBuilder) checkProviderUpgradePreviewOnly(t *testing.T) {
+	info := b.newProviderUpgradeInfo(t)
+	t.Logf("Baseline provider version: %s", info.baselineProviderVersion)
+
+	opts := integration.ProgramTestOptions{
+		Dir: info.testCaseDir,
+		Env: []string{},
+
+		// Skips are required by programTestHelper.previewOnlyUpgradeTest
+		SkipUpdate:       true,
+		SkipRefresh:      true,
+		SkipExportImport: true,
+	}
+
+	ambientProvider, _ := exec.LookPath(b.providerBinary())
+	require.NotEmptyf(t, ambientProvider, "expected to find a release candidate provider "+
+		"binary in PATH, try to call `make provider` and `export PATH=$PWD/bin:$PATH`")
+
+	pth := newProgramTestHelper(t, opts)
+	t.Logf("%v", pth)
+	err := pth.previewOnlyUpgradeTest(info.stateFile)
+	require.NoError(t, err)
+}
+
+func (b *providerUpgradeBuilder) providerBinary() string {
+	return fmt.Sprintf("pulumi-resource-%s", b.name)
+}
+
+// Preview-only integration test.
+
+type programTestHelper struct {
+	t         *testing.T
+	opts      integration.ProgramTestOptions
+	pt        *integration.ProgramTester
+	stackName string
+}
+
+func newProgramTestHelper(t *testing.T, opts integration.ProgramTestOptions) *programTestHelper {
+	require.Falsef(t, opts.RunUpdateTest, "RunUpdateTest is not supported")
+	require.Emptyf(t, opts.StackName, "Custom StackName is not supported")
+	// Allocate stack name.
+	stackName := opts.GetStackName()
+	require.NotEmptyf(t, opts.StackName,
+		"Expected GetStackName() to allocate a random stack name")
+	pt := integration.ProgramTestManualLifeCycle(t, &opts)
+	return &programTestHelper{
+		t:         t,
+		opts:      opts,
+		pt:        pt,
+		stackName: string(stackName),
+	}
+}
+
+func (pth *programTestHelper) previewOnlyUpgradeTest(stateFile string) error {
+	t := pth.t
+	pt := pth.pt
+	opts := pth.opts
+	return pth.lifecycleInitAndDestroy(func() error {
+		t.Logf("Importing pre-recorded stateFile from the baseline provider version")
+		fixedStateFile := pth.fixupStackName(stateFile)
+		if err := pt.RunPulumiCommand("stack", "import",
+			"--file", fixedStateFile); err != nil {
+			return err
+		}
+
+		t.Logf("Running preview using the new provider version")
+		// Only run preview. There is no dedicated API for that so instead we check that
+		// flags disable everything else. This runs preview twice unfortunately, it's the
+		// second one that needs to run. The second preview is gated by
+		// SkipEmptyPreviewUpdate and is checking that there are no unexpected updates.
+		//
+		// If this code could run just pt.PreviewAndUpdate that would be better but it needs
+		// to access pt.dir which is kept private.
+		require.Falsef(t, opts.SkipPreview,
+			"previewOnlyUpgradeTest is incompatible with SkipPreview")
+		require.True(t, opts.SkipUpdate, "expecting SkipUpdate: true")
+		require.True(t, opts.SkipRefresh, "expecting SkipRefresh: true")
+		require.True(t, opts.SkipExportImport, "expecting SkipExportImport: true")
+		require.Falsef(t, opts.SkipEmptyPreviewUpdate,
+			"expecting SkipEmptyPreviewUpdate: false")
+		require.Emptyf(t, opts.EditDirs,
+			"previewOnlyUpgradeTest is incompatible with EditDirs")
+		if err := pt.TestPreviewUpdateAndEdits(); err != nil {
+			return fmt.Errorf("running test preview: %w", err)
+		}
+		return nil
+	})
+}
+
+func (pth *programTestHelper) fixupStackName(stateFile string) string {
+	t := pth.t
+	stackName := pth.stackName
+	tempDir := t.TempDir()
+	state := readFile(t, stateFile)
+	//t.Logf("prior state: %v", state)
+	fixedState := pth.withUpdatedStackName(stackName, state)
+	fixedStateFile := filepath.Join(tempDir, "fixed-state.json")
+	//t.Logf("fixed state: %v", fixedState)
+	writeFile(t, fixedStateFile, []byte(fixedState))
+	return fixedStateFile
+}
+
+// Behaves just like pt.TestLifeCycleInitAndDestroy() but with custom inner test logic. This
+// function was obtained by inlining TestLifeCycleInitAndDestroy implementation and generalizing it.
+func (pth *programTestHelper) lifecycleInitAndDestroy(customTest func() error) error {
+	assert.Falsef(pth.t, pth.opts.RunUpdateTest, "RunUpdateTest is not supported")
+
+	err := pth.pt.TestLifeCyclePrepare()
+	if err != nil {
+		return fmt.Errorf("copying test to temp dir %s: %w", "<tmpdir>", err)
+	}
+
+	pth.pt.TestFinished = false
+	if pth.opts.DestroyOnCleanup {
+		pth.t.Cleanup(pth.pt.TestCleanUp)
+	} else {
+		defer pth.pt.TestCleanUp()
+	}
+
+	err = pth.pt.TestLifeCycleInitialize()
+	if err != nil {
+		return fmt.Errorf("initializing test project: %w", err)
+	}
+
+	destroyStack := func() {
+		destroyErr := pth.pt.TestLifeCycleDestroy()
+		assert.NoError(pth.t, destroyErr)
+	}
+	if pth.opts.DestroyOnCleanup {
+		// Allow other tests to refer to this stack until the test is complete.
+		pth.t.Cleanup(destroyStack)
+	} else {
+		// Ensure that before we exit, we attempt to destroy and remove the stack.
+		defer destroyStack()
+	}
+
+	if err = customTest(); err != nil {
+		return err
+	}
+
+	pth.pt.TestFinished = true
+	return nil
+}
+
+func (pth *programTestHelper) withUpdatedStackName(newStackName string, state string) string {
+	pth.t.Logf("Replacing %q with %q", pth.parseStackName(state), newStackName)
+	return strings.ReplaceAll(state, pth.parseStackName(state), newStackName)
+}
+
+func (pth *programTestHelper) parseStackName(state string) string {
+	t := pth.t
+	type model struct {
+		Deployment struct {
+			Resources []struct {
+				URN  string `json:"urn"`
+				Type string `json:"type"`
+			} `json:"resources"`
+		} `json:"deployment"`
+	}
+	var m model
+	err := json.Unmarshal([]byte(state), &m)
+	require.NoError(t, err)
+	var stackUrn string
+	for _, r := range m.Deployment.Resources {
+		if r.Type == "pulumi:pulumi:Stack" {
+			stackUrn = r.URN
+		}
+	}
+	return strings.Split(stackUrn, ":")[2]
+}
+
+func (b *providerUpgradeBuilder) providerUpgradeRecordBaselines(t *testing.T) {
+	info := b.newProviderUpgradeInfo(t)
+	ambientProvider, _ := exec.LookPath(b.providerBinary())
+	require.Emptyf(t, ambientProvider, "please remove the provider from PATH")
+	ensureFolderExists(t, info.recordingDir)
+	deleteFileIfExists(t, info.stateFile)
+	deleteFileIfExists(t, info.grpcFile)
+	test := info.opts.With(integration.ProgramTestOptions{
+		Env: append(info.opts.Env, fmt.Sprintf("PULUMI_DEBUG_GRPC=%s", info.grpcFile)),
+		ExportStateValidator: func(t *testing.T, state []byte) {
+			writeFile(t, info.stateFile, state)
+			t.Logf("wrote %s", info.stateFile)
+		},
+
+		// TODO eks.Cluster fails refresh on 5.42.0
+		SkipRefresh: true,
+	})
+	integration.ProgramTest(t, &test)
+}

--- a/upgrade.go
+++ b/upgrade.go
@@ -31,9 +31,9 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"gopkg.in/yaml.v3"
 
+	"github.com/pulumi/providertest/flags"
 	testutils "github.com/pulumi/pulumi-terraform-bridge/testing/x"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
@@ -200,11 +200,9 @@ type providerUpgradeBuilder struct {
 
 func (b *providerUpgradeBuilder) run(t *testing.T, mode UpgradeTestMode) {
 	b.verifyVersion()
-	acceptEnvVar := "PULUMI_ACCEPT"
-	accept := cmdutil.IsTruthy(os.Getenv(acceptEnvVar))
-	if accept {
-		b.tt.Logf("Recording baseline behavior as requested by "+
-			"setting %q env var", acceptEnvVar)
+
+	if flags.Snapshot.IsSet() {
+		b.tt.Logf("Recording baseline behavior because %s", flags.Snapshot.WhySet())
 		b.providerUpgradeRecordBaselines(b.tt)
 	}
 
@@ -223,7 +221,7 @@ func (b *providerUpgradeBuilder) run(t *testing.T, mode UpgradeTestMode) {
 			return
 		}
 
-		if accept {
+		if flags.Snapshot.IsSet() {
 			t.Skipf("Skipping because baselines were just pre-recorded")
 		} else {
 			b.checkProviderUpgradePreviewOnly(t)

--- a/upgrade.go
+++ b/upgrade.go
@@ -119,7 +119,7 @@ const (
 	UpgradeTestMode_Quick UpgradeTestMode = iota
 
 	// The medium precision/speed mode. Imports Pulumi statefile recorded on a baseline version,
-	// and performs pulumi preview, assrting that the preview results in an empty diff. Cloud
+	// and performs pulumi preview, asserting that the preview results in an empty diff. Cloud
 	// credentials are required, but no infra is actually provisioned, making it quicker to
 	// verify slow-to-provision resources such as databases.
 	UpgradeTestMode_PreviewOnly


### PR DESCRIPTION
This mini-framework is being lifted out of pulumi-aws to enable reuse in pulumi-gcp and further down.

Sister PRs: 

- https://github.com/pulumi/pulumi-gcp/pull/1237 
- https://github.com/pulumi/pulumi-aws/pull/2855 (may be a bit out of date)

VerifyUpgrade makes sure that a stack provisioned under a baseline version of provider will not have any replacements when upgrading to the current (under test) version of the provider.

Fixes:
- https://github.com/pulumi/home/issues/3127
- https://github.com/pulumi/home/issues/3128 (instead of ProgramTest using this providertest pre-1.0 repo for now before the functionality ossifies)
