### PR TITLE
Fix update-snapshot handling

### DIFF
--- a/providertest.go
+++ b/providertest.go
@@ -181,6 +181,17 @@ func (pt *ProviderTest) Run(t *testing.T) {
 		}
 		pt.RunSdk(t, "typescript")
 	})
+
+	t.Run("upgrade-snapshot", func(t *testing.T) {
+		t.Helper()
+		if flags.Snapshot.IsSet() {
+			t.Logf("Recording baseline behavior because %s", flags.Snapshot.WhySet())
+			pt.VerifyUpgradeSnapshot(t)
+		} else {
+			t.Skipf("Skip recording baseline behavior because %s", flags.Snapshot.WhyNotSet())
+		}
+	})
+
 	for _, m := range UpgradeTestModes() {
 		t.Run(fmt.Sprintf("upgrade-%s", m), func(t *testing.T) {
 			t.Helper()


### PR DESCRIPTION
Fixing a small omission.. I'm testing this on GCP and noticed that with latest changes, recording the snapshot does it 3x times .. for each Mode of the Upgrade test. That's not great. With these changes snapshot only records once, and in addition better error messages are printed when snapshot is absent so the test cannot run without it.