### PR TITLE
Fixes #5 - new home for low-level replay tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,11 @@ module github.com/pulumi/providertest
 go 1.21.0
 
 require (
-	github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1
 	github.com/pulumi/pulumi/pkg/v3 v3.86.0
 	github.com/pulumi/pulumi/sdk/v3 v3.86.0
 	github.com/stretchr/testify v1.8.3
 	google.golang.org/protobuf v1.31.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -206,7 +205,6 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/frand v1.4.2 // indirect
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1464,8 +1464,6 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/prometheus v0.35.0/go.mod h1:7HaLx5kEPKJ0GDgbODG0fZgXbQ8K/XjZNJXQmbmgQlY=
 github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGOON44WyAp4Xqbbk=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1 h1:SCg1gjfY9N4yn8U8peIUYATifjoDABkyR7H9lmefsfc=
-github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1/go.mod h1:7OeUPH8rpt5ipyj9EFcnXpuzQ8SHL0dyqdfa8nOacdk=
 github.com/pulumi/pulumi/pkg/v3 v3.86.0 h1:G4spuT89ZN8lSxT9WkMF/JaP7n+wu7ubEly7Yy8uza0=
 github.com/pulumi/pulumi/pkg/v3 v3.86.0/go.mod h1:Qs55gPhUwM/Dua3VRtHXLLlpY8uEe+llDBIZc+1pvHM=
 github.com/pulumi/pulumi/sdk/v3 v3.86.0 h1:Cxg0rGdvMt9GqGvesFTj8+WaO/ihmALYlQf4zm1GzFw=

--- a/replay/json_match.go
+++ b/replay/json_match.go
@@ -1,0 +1,143 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replay
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Assert that a given JSON document structurally matches a pattern.
+//
+// The pattern language supports the following constructs:
+//
+// "*" matches anything.
+//
+// {"\\": x} matches only JSON documents strictly equal to x. This pattern essentially escapes the sub-tree, for example
+// use {"\\": "*"} to match only the literal string "*".
+func AssertJSONMatchesPattern(
+	t *testing.T,
+	expectedPattern json.RawMessage,
+	actual json.RawMessage,
+) {
+
+	var p, a interface{}
+
+	if err := json.Unmarshal(expectedPattern, &p); err != nil {
+		require.NoError(t, err)
+	}
+
+	if err := json.Unmarshal(actual, &a); err != nil {
+		require.NoError(t, err)
+	}
+
+	detectEscape := func(m map[string]interface{}) (interface{}, bool) {
+		if len(m) != 1 {
+			return nil, false
+		}
+		for k, v := range m {
+			if k == "\\" {
+				return v, true
+			}
+		}
+		return nil, false
+	}
+
+	var match func(path string, p, a interface{})
+	match = func(path string, p, a interface{}) {
+		switch pp := p.(type) {
+		case string:
+			if pp != "*" {
+				assertJSONEquals(t, path, p, a)
+			}
+		case []interface{}:
+			aa, ok := a.([]interface{})
+			if !ok {
+				t.Errorf("[%s]: expected an array, but got %s", path, prettyJSON(t, a))
+				return
+			}
+			if len(aa) != len(pp) {
+				t.Errorf("[%s]: expected an array of length %d, but got %s",
+					path, len(pp), prettyJSON(t, a))
+			}
+			for i, pv := range pp {
+				av := aa[i]
+				match(fmt.Sprintf("%s[%d]", path, i), pv, av)
+			}
+		case map[string]interface{}:
+			if esc, isEsc := detectEscape(pp); isEsc {
+				assertJSONEquals(t, path, esc, a)
+				return
+			}
+
+			aa, ok := a.(map[string]interface{})
+			if !ok {
+				t.Errorf("[%s]: expected an object, but got %s", path, prettyJSON(t, a))
+				return
+			}
+
+			seenKeys := map[string]bool{}
+			allKeys := []string{}
+
+			for k := range pp {
+				if !seenKeys[k] {
+					allKeys = append(allKeys, k)
+				}
+				seenKeys[k] = true
+			}
+
+			for k := range aa {
+				if !seenKeys[k] {
+					allKeys = append(allKeys, k)
+				}
+				seenKeys[k] = true
+			}
+			sort.Strings(allKeys)
+
+			for _, k := range allKeys {
+				pv, gotPV := pp[k]
+				av, gotAV := aa[k]
+				subPath := fmt.Sprintf("%s[%q]", path, k)
+				switch {
+				case gotPV && gotAV:
+					match(subPath, pv, av)
+				case !gotPV && gotAV:
+					t.Errorf("[%s] unexpected value %s", subPath, prettyJSON(t, av))
+				case gotPV && !gotAV:
+					t.Errorf("[%s] missing a required value", subPath)
+				}
+			}
+		default:
+			assertJSONEquals(t, path, p, a)
+		}
+	}
+
+	match("#", p, a)
+}
+
+func assertJSONEquals(t *testing.T, path string, expected, actual interface{}) {
+	assert.Equalf(t, prettyJSON(t, expected), prettyJSON(t, actual), "at %s", path)
+}
+
+func prettyJSON(t *testing.T, msg interface{}) string {
+	bytes, err := json.MarshalIndent(msg, "", "  ")
+	assert.NoError(t, err)
+	return string(bytes)
+}

--- a/replay/json_match_test.go
+++ b/replay/json_match_test.go
@@ -1,0 +1,28 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replay
+
+import (
+	"testing"
+)
+
+func TestJsonMatch(t *testing.T) {
+	AssertJSONMatchesPattern(t, []byte(`1`), []byte(`1`))
+	AssertJSONMatchesPattern(t, []byte(`"*"`), []byte(`1`))
+	AssertJSONMatchesPattern(t, []byte(`"*"`), []byte(`2`))
+	AssertJSONMatchesPattern(t, []byte(`{"\\": "*"}`), []byte(`"*"`))
+	AssertJSONMatchesPattern(t, []byte(`[1, "*", 3]`), []byte(`[1, 2, 3]`))
+	AssertJSONMatchesPattern(t, []byte(`{"foo": "*", "bar": 3}`), []byte(`{"foo": 1, "bar": 3}`))
+}

--- a/replay/package.go
+++ b/replay/package.go
@@ -1,0 +1,24 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Replay tests allow to quickly add regression tests that exercise one or a small number of gRPC
+// methods.
+//
+// How this works: once a problem reproduces, run Pulumi with PULUMI_DEBUG_GRPC="$PWD/logs.json"
+// flag, find the offending method record under "logs.json" and turn it into a test using Replay
+// from this package.
+//
+// Note: this package used to be exposed under pulumi/pulumi-terraform-bridge/testing Go module but
+// is moving here as it is not specific to bridged providers.
+package replay

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -1,0 +1,239 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replay
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	jsonpb "google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+// Replay executes a request from a provider operation log against an in-memory resource provider server and asserts
+// that the server's response matches the logged response.
+//
+// The jsonLog parameter is a verbatim JSON string such as this one:
+//
+//	{
+//	  "method": "/pulumirpc.ResourceProvider/Create",
+//	  "request": {
+//	    "urn": "urn:pulumi:dev::repro-pulumi-random::random:index/randomString:RandomString::s",
+//	    "properties": {
+//	      "length": 1
+//	    }
+//	  },
+//	  "response": {
+//	    "id": "*",
+//	    "properties": {
+//	      "__meta": "{\"schema_version\":\"2\"}",
+//	      "id": "*",
+//	      "result": "*",
+//	      "length": 1,
+//	      "lower": true,
+//	      "minLower": 0,
+//	      "minNumeric": 0,
+//	      "minSpecial": 0,
+//	      "minUpper": 0,
+//	      "number": true,
+//	      "numeric": true,
+//	      "special": true,
+//	      "upper": true
+//	    }
+//	  }
+//	}
+//
+// The format is the JSON encoding of the gRPC protocol used by Pulumi ResourceProvider service.
+//
+//	https://github.com/pulumi/pulumi/blob/master/proto/pulumi/provider.proto#L27
+//
+// Conveniently, the format matches what Pulumi CLI emits when invoked with PULUMI_DEBUG_GPRC:
+//
+//	PULUMI_DEBUG_GPRC=$PWD/log.json pulumi up
+//
+// This allows quickly turning fragments of the program execution trace into test cases.
+//
+// Instead of direct JSON equality, Replay uses AssertJSONMatchesPattern to compare the actual and expected responses.
+// This allows patterns such as "*". In the above example, the random provider will generate new strings with every
+// invocation and they would fail a strict equality check. Using "*" allows the test to succeed while ignoring the
+// randomness.
+//
+// Beware possible side-effects: although Replay executes in-memory without actual gRPC sockets, replaying against an
+// actual resource provider will side-effect. For example, replaying Create calls against pulumi-aws provider may try to
+// create resorces in AWS. This is not an issue with side-effect-free providers such as pulumi-random, or for methods
+// that do not involve cloud interaction such as Diff.
+//
+// Replay does not assume that the provider is a bridged provider and can be generally useful.
+func Replay(t *testing.T, server pulumirpc.ResourceProviderServer, jsonLog string) {
+	ctx := context.Background()
+	var entry jsonLogEntry
+	err := json.Unmarshal([]byte(jsonLog), &entry)
+	assert.NoError(t, err)
+
+	switch entry.Method {
+
+	case "/pulumirpc.ResourceProvider/GetSchema":
+		replay(t, entry, new(pulumirpc.GetSchemaRequest), server.GetSchema)
+
+	case "/pulumirpc.ResourceProvider/CheckConfig":
+		replay(t, entry, new(pulumirpc.CheckRequest), server.CheckConfig)
+
+	case "/pulumirpc.ResourceProvider/DiffConfig":
+		replay(t, entry, new(pulumirpc.DiffRequest), server.DiffConfig)
+
+	case "/pulumirpc.ResourceProvider/Configure":
+		replay(t, entry, new(pulumirpc.ConfigureRequest), server.Configure)
+
+	case "/pulumirpc.ResourceProvider/Invoke":
+		replay(t, entry, new(pulumirpc.InvokeRequest), server.Invoke)
+
+	// TODO StreamInvoke might need some special handling as it is a streaming RPC method.
+
+	case "/pulumirpc.ResourceProvider/Call":
+		replay(t, entry, new(pulumirpc.CallRequest), server.Call)
+
+	case "/pulumirpc.ResourceProvider/Check":
+		replay(t, entry, new(pulumirpc.CheckRequest), server.Check)
+
+	case "/pulumirpc.ResourceProvider/Diff":
+		replay(t, entry, new(pulumirpc.DiffRequest), server.Diff)
+
+	case "/pulumirpc.ResourceProvider/Create":
+		replay(t, entry, new(pulumirpc.CreateRequest), server.Create)
+
+	case "/pulumirpc.ResourceProvider/Read":
+		replay(t, entry, new(pulumirpc.ReadRequest), server.Read)
+
+	case "/pulumirpc.ResourceProvider/Update":
+		replay(t, entry, new(pulumirpc.UpdateRequest), server.Update)
+
+	case "/pulumirpc.ResourceProvider/Delete":
+		replay(t, entry, new(pulumirpc.DeleteRequest), server.Delete)
+
+	case "/pulumirpc.ResourceProvider/Construct":
+		replay(t, entry, new(pulumirpc.ConstructRequest), server.Construct)
+
+	case "/pulumirpc.ResourceProvider/Cancel":
+		_, err := server.Cancel(ctx, &emptypb.Empty{})
+		assert.NoError(t, err)
+
+	// TODO GetPluginInfo is a bit odd in that it has an Empty request, need to generealize replay() function.
+	//
+	// rpc GetPluginInfo(google.protobuf.Empty) returns (PluginInfo) {}
+
+	case "/pulumirpc.ResourceProvider/Attach":
+		replay(t, entry, new(pulumirpc.PluginAttach), server.Attach)
+
+	case "/pulumirpc.ResourceProvider/GetMapping":
+		replay(t, entry, new(pulumirpc.GetMappingRequest), server.GetMapping)
+
+	case "/pulumirpc.ResourceProvider/GetMappings":
+		replay(t, entry, new(pulumirpc.GetMappingsRequest), server.GetMappings)
+
+	default:
+		t.Errorf("Unknown method: %s", entry.Method)
+	}
+}
+
+// ReplaySequence is exactly like Replay, but expects jsonLog to encode a sequence of events `[e1, e2, e3]`, and will
+// call Replay on each of those events in the given order.
+func ReplaySequence(t *testing.T, server pulumirpc.ResourceProviderServer, jsonLog string) {
+	var entries []jsonLogEntry
+	err := json.Unmarshal([]byte(jsonLog), &entries)
+	assert.NoError(t, err)
+	for _, e := range entries {
+		bytes, err := json.Marshal(e)
+		assert.NoError(t, err)
+		Replay(t, server, string(bytes))
+	}
+}
+
+func replay[Req protoreflect.ProtoMessage, Resp protoreflect.ProtoMessage](
+	t *testing.T,
+	entry jsonLogEntry,
+	req Req,
+	serve func(context.Context, Req) (Resp, error),
+) {
+	ctx := context.Background()
+
+	err := jsonpb.Unmarshal([]byte(entry.Request), req)
+	assert.NoError(t, err)
+
+	resp, err := serve(ctx, req)
+	require.NoError(t, err)
+
+	bytes, err := jsonpb.Marshal(resp)
+	assert.NoError(t, err)
+
+	var expected, actual json.RawMessage = entry.Response, bytes
+
+	AssertJSONMatchesPattern(t, expected, actual)
+}
+
+// ReplayFile executes ReplaySequence on all pulumirpc.ResourceProvider events found in the file produced with
+// PULUMI_DEBUG_GPRC. For example:
+//
+//	PULUMI_DEBUG_GPRC=testdata/log.json pulumi up
+//
+// This produces the testdata/log.json file, which can then be used for Replay-style testing:
+//
+//	ReplayFile(t, server, "testdata/log.json")
+func ReplayFile(t *testing.T, server pulumirpc.ResourceProviderServer, traceFile string) {
+	bytes, err := os.ReadFile(traceFile)
+	require.NoError(t, err)
+
+	var entries []jsonLogEntry
+	err = json.Unmarshal(bytes, &entries)
+	require.NoError(t, err)
+
+	count := 0
+	for _, entry := range entries {
+		if entry.Method == "" {
+			continue
+		}
+
+		if !strings.HasPrefix(entry.Method, "/pulumirpc.ResourceProvider") {
+			continue
+		}
+		// TODO support replaying all these method calls.
+		switch entry.Method {
+		case "/pulumirpc.ResourceProvider/StreamInvoke":
+			continue
+		case "/pulumirpc.ResourceProvider/GetPluginInfo":
+			continue
+		default:
+			entryBytes, err := json.Marshal(entry)
+			require.NoError(t, err)
+			Replay(t, server, string(entryBytes))
+			count++
+		}
+	}
+	assert.Greater(t, count, 0)
+}
+
+type jsonLogEntry struct {
+	Method   string          `json:"method"`
+	Request  json.RawMessage `json:"request,omitempty"`
+	Response json.RawMessage `json:"response,omitempty"`
+}

--- a/upgrade.go
+++ b/upgrade.go
@@ -31,7 +31,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/pulumi/providertest/flags"
-	testutils "github.com/pulumi/pulumi-terraform-bridge/testing/x"
+	"github.com/pulumi/providertest/replay"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -306,7 +306,7 @@ func (e *mockPulumiEngine) replayGRPCLog(t *testing.T, jsonLog string) {
 		entry.Request = marshalProto(t, req)
 		b, err := json.Marshal(entry)
 		require.NoError(t, err)
-		testutils.Replay(t, e.provider, string(b))
+		replay.Replay(t, e.provider, string(b))
 		e.verifiedDiffResourceCounter++
 		t.Logf("Replayed Diff on %v", req.Urn)
 	}


### PR DESCRIPTION
Fixes #5 

This is actually not as critical as I thought because the repo does not depend on the bridge, but only on the `github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1` module, so the transitive dependencies are fine. I do think however that this may be a better home for the low-level replay functionality than the bridge, especially since it assumes exactly nothing about the provider being bridged or not.
