### PR TITLE
Implements more precise diff validation

### DIFF
--- a/upgrade.go
+++ b/upgrade.go
@@ -230,6 +230,16 @@ func NoChanges() DiffValidation {
 	}
 }
 
+func NoReplacements() DiffValidation {
+	return func(t *testing.T, diffs Diffs) {
+		for _, d := range diffs {
+			if d.HasChanges {
+				assert.Emptyf(t, d.Replaces, "Unexpected replacement plan for %v", d.URN)
+			}
+		}
+	}
+}
+
 type providerUpgradeOpts struct {
 	baselineVersion        string
 	modes                  map[UpgradeTestMode]string // skip reason by mode

--- a/upgrade.go
+++ b/upgrade.go
@@ -206,11 +206,26 @@ func WithResourceProviderServer(s pulumirpc.ResourceProviderServer) Option {
 	return func(b *ProviderTest) { b.upgradeOpts.resourceProviderServer = s }
 }
 
+// The structure is mapped directly from Pulumi gRPC DiffResponse structure in the provider protocol
+// and is currently unstable / subject to change.
+//
+// https://github.com/pulumi/pulumi/blob/master/proto/pulumi/provider.proto#L225
+//
+// Need to verify if this is representative of the actual Pulumi plans, since it only considers the
+// decisions made by the provider, not the engine. For example, unclear if replaceOnChanges option
+// https://www.pulumi.com/docs/concepts/options/replaceonchanges/ would surface here.
+//
+// Even with the above caveats, it is reasonable to rely on this for the purposes of testing the
+// provider itself.
 type Diff struct {
-	URN                 resource.URN
-	HasChanges          bool
+	URN        resource.URN
+	HasChanges bool
+
+	// Non-empty Replaces indicates that the plan is a resource replacement and not a simple
+	// in-place update.
+	Replaces []string
+
 	Diffs               []string
-	Replaces            []string
 	DeleteBeforeReplace bool
 }
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/providertest/issues/24

For PreviewOnly upgrade tests, the user is now able to write custom validations over what changes are permitted or not. This relies on inspecting Diff method logs. Two canned strategies are provided, NoChanges which is the default, and NoReplacements which is more lenient. Custom code can narrow this down further, for example only prohibiting replacements by type.