### PR TITLE
Consider DiffConfig, show old and new values of diffs, handle empty Changes

### DIFF
--- a/upgrade.go
+++ b/upgrade.go
@@ -760,7 +760,7 @@ func verifyChanges(t *testing.T, grpcLogsFile string, diffV DiffValidation) {
 		err = json.Unmarshal([]byte(s), &entry)
 		require.NoError(t, err)
 
-		if entry.Method == "/pulumirpc.ResourceProvider/Diff" {
+		if entry.Method == "/pulumirpc.ResourceProvider/Diff" || entry.Method == "/pulumirpc.ResourceProvider/DiffConfig" {
 			urn, err := resource.ParseURN(entry.Request.URN)
 			require.NoError(t, err)
 

--- a/upgrade.go
+++ b/upgrade.go
@@ -227,6 +227,11 @@ type Diff struct {
 
 	Diffs               []string
 	DeleteBeforeReplace bool
+
+	// May only be populated if there's a change.
+	Olds map[string]any
+	// May only be populated if there's a change.
+	News map[string]any
 }
 
 type Diffs []Diff
@@ -240,7 +245,7 @@ func WithDiffValidation(valid DiffValidation) Option {
 func NoChanges() DiffValidation {
 	return func(t *testing.T, diffs Diffs) {
 		for _, d := range diffs {
-			assert.Falsef(t, d.HasChanges, "Expected no changes for %v", d.URN)
+			assert.Falsef(t, d.HasChanges, "Expected no changes for %v", d)
 		}
 	}
 }
@@ -249,7 +254,7 @@ func NoReplacements() DiffValidation {
 	return func(t *testing.T, diffs Diffs) {
 		for _, d := range diffs {
 			if d.HasChanges {
-				assert.Emptyf(t, d.Replaces, "Unexpected replacement plan for %v", d.URN)
+				assert.Emptyf(t, d.Replaces, "Unexpected replacement plan for %v", d)
 			}
 		}
 	}
@@ -733,7 +738,9 @@ func verifyChanges(t *testing.T, grpcLogsFile string, diffV DiffValidation) {
 	require.NoError(t, err)
 
 	type req struct {
-		URN string `json:"urn"`
+		URN  string         `json:"urn"`
+		Olds map[string]any `json:"olds"`
+		News map[string]any `json:"news"`
 	}
 
 	type resp struct {
@@ -746,7 +753,7 @@ func verifyChanges(t *testing.T, grpcLogsFile string, diffV DiffValidation) {
 	type log struct {
 		Method   string `json:"method"`
 		Request  req    `json:"request"`
-		Repsonse resp   `json:"response"`
+		Response resp   `json:"response"`
 	}
 
 	var diffs Diffs
@@ -764,13 +771,28 @@ func verifyChanges(t *testing.T, grpcLogsFile string, diffV DiffValidation) {
 			urn, err := resource.ParseURN(entry.Request.URN)
 			require.NoError(t, err)
 
-			diffs = append(diffs, Diff{
+			d := Diff{
 				URN:                 urn,
-				HasChanges:          entry.Repsonse.Changes != "DIFF_NONE",
-				Diffs:               entry.Repsonse.Diffs,
-				Replaces:            entry.Repsonse.Replaces,
-				DeleteBeforeReplace: entry.Repsonse.DeleteBeforeReplace,
-			})
+				HasChanges:          entry.Response.Changes != "" && entry.Response.Changes != "DIFF_NONE",
+				Diffs:               entry.Response.Diffs,
+				Replaces:            entry.Response.Replaces,
+				DeleteBeforeReplace: entry.Response.DeleteBeforeReplace,
+			}
+
+			if d.HasChanges {
+				d.Olds = map[string]any{}
+				d.News = map[string]any{}
+				for _, rep := range d.Replaces {
+					d.Olds[rep] = entry.Request.Olds[rep]
+					d.News[rep] = entry.Request.News[rep]
+				}
+				for _, diffProp := range d.Diffs {
+					d.Olds[diffProp] = entry.Request.Olds[diffProp]
+					d.News[diffProp] = entry.Request.News[diffProp]
+				}
+			}
+
+			diffs = append(diffs, d)
 		}
 	}
 

--- a/upgrade.go
+++ b/upgrade.go
@@ -462,7 +462,11 @@ func (b *providerUpgradeBuilder) checkProviderUpgradePreviewOnly(t *testing.T) {
 		return
 	}
 
-	previewLogs := filepath.Join(t.TempDir(), "preview-grpc-logs.json")
+	previewLogs := os.Getenv("PULUMI_DEBUG_GRPC")
+	if previewLogs == "" {
+		previewLogs = filepath.Join(t.TempDir(), "preview-grpc-logs.json")
+	}
+	t.Logf("Recording preview gRPC logs to %s", previewLogs)
 
 	opts := integration.ProgramTestOptions{
 		Dir:    b.program,


### PR DESCRIPTION
This PRs contains ~~three~~four changes, one of which was unfortunately hard to disentangle and another one doesn't warrant its own PR, so here they are. By commit:
- Consider `DiffConfig` events as well as `Diff` to catch provider version changes etc. For instance, the p-kubernetes major version change observed in the EKS v2 tests is part of `DiffConfig`.
- Show the old and new values when there's a diff.
  - This helps with understanding what changed. To avoid noisy and hard-to-read output, it only shows the differing values, not all of old/new.
  - This commit also contains a bugfix to handle when `Response.Changes` is empty in addition to being `DIFF_NONE`. Without this change, I saw supposed diffs that had no actually changed values.
- Allow setting `PULUMI_DEBUG_GRPC` before running the test and honor that value. Use a temporary, ephemeral location otherwise. This allows capturing the gRPC logs for inspection after the test run.
