### PR TITLE
Run recording if no snapshot exists

### DIFF
--- a/upgrade.go
+++ b/upgrade.go
@@ -458,8 +458,7 @@ func (b *providerUpgradeBuilder) checkProviderUpgradePreviewOnly(t *testing.T) {
 
 	// Skip if state not yet created
 	if _, err := os.Stat(info.stateFile); os.IsNotExist(err) {
-		t.Skipf("No pre-recorded state found for %s. Run in 'snapshot' mode to capture the current state produced by the current provider version.", b.baselineVersion)
-		return
+		b.providerUpgradeRecordBaselines(t)
 	}
 
 	previewLogs := os.Getenv("PULUMI_DEBUG_GRPC")

--- a/upgrade.go
+++ b/upgrade.go
@@ -458,6 +458,7 @@ func (b *providerUpgradeBuilder) checkProviderUpgradePreviewOnly(t *testing.T) {
 
 	// Skip if state not yet created
 	if _, err := os.Stat(info.stateFile); os.IsNotExist(err) {
+		t.Logf("No pre-recorded state found for %s, recording baseline behaviour.", b.baselineVersion)
 		b.providerUpgradeRecordBaselines(t)
 	}
 


### PR DESCRIPTION
This should simplify the recording process by avoiding the user having to run with special flags.

Re-recording snapshots should also be easier because the existing snapshot just needs deleting and the tests re-running.

- Fixes https://github.com/pulumi/providertest/issues/32