### PR TITLE
Refine default options

### DIFF
--- a/pulumitest/README.md
+++ b/pulumitest/README.md
@@ -15,7 +15,7 @@ func TestPulumiProgram(t *testing.T) {
 }
 ```
 
-By default run your program is copied to a temporary directory before running to avoid cluttering your working directory with temporary or ephemeral files. To disable this behaviour, use `opttest.TestInPlace()`. You can also do a copy of a test manually by calling `CopyToTempDir()`:
+By default your program is copied to a temporary directory before running to avoid cluttering your working directory with temporary or ephemeral files. To disable this behaviour, use `opttest.TestInPlace()`. You can also do a copy of a test manually by calling `CopyToTempDir()`:
 
 ```go
 source := NewPulumiTest(t, opttest.TestInPlace())
@@ -24,18 +24,24 @@ copy := source.CopyToTempDir()
 
 The `source` variable is still pointing to the original path, but the `copy` is pointing to a new PulumiTest in temporary directory which will automatically get removed at the end of the test.
 
-Before we can preview or deploy a program we need to install dependencies and create a stack:
+The default behaviour is also to install dependencies and create a new stack called "test".
+
+- The default stack name can be customised by using `opttest.StackName("my-stack")`.
+- To prevent the automatic install of dependencies use `opttest.SkipInstall()`.
+- To prevent automatically creating a stack use `opttest.SkipStackCreate()`
+
+The following program is equivalent to the default test setup:
 
 ```go
-//...
+test := NewPulumiTest(t, opttest.SkipInstall(), opttest.SkipStackCreate())
 test.Install() // Runs `pulumi install` to restore all dependencies
-test.NewStack("my-stack") // Creates a new stack and returns it.
+test.NewStack("test") // Creates a new stack and returns it.
 ```
 
-These two steps can also be done together by calling `InstallStack()`:
+The `Install` and `NewStack` steps can also be done together by calling `InstallStack()`:
 
 ```go
-test.InstallStack("my-stack")
+test.InstallStack("test")
 ```
 
 The created stack is returned but is also set as the current stack on the PulumiTest object. All methods such as `source.Preview()` or `source.Up()` will use this current stack.

--- a/pulumitest/README.md
+++ b/pulumitest/README.md
@@ -15,10 +15,10 @@ func TestPulumiProgram(t *testing.T) {
 }
 ```
 
-By default run your program is copied to a temporary directory before running to avoid cluttering your working directory with temporary or ephemeral files. To disable this behaviour, use `NewPulumiTestInPlace`. You can also do a copy of a test manually by calling `CopyToTempDir()`:
+By default run your program is copied to a temporary directory before running to avoid cluttering your working directory with temporary or ephemeral files. To disable this behaviour, use `opttest.TestInPlace()`. You can also do a copy of a test manually by calling `CopyToTempDir()`:
 
 ```go
-source := NewPulumiTestInPlace(t, ...)
+source := NewPulumiTest(t, opttest.TestInPlace())
 copy := source.CopyToTempDir()
 ```
 

--- a/pulumitest/assertpreview/asserts.go
+++ b/pulumitest/assertpreview/asserts.go
@@ -15,7 +15,7 @@ func HasNoChanges(t *testing.T, preview auto.PreviewResult) {
 	unexpectedOps := convertedMap.WhereOpNotEquals(apitype.OpSame)
 
 	if len(*unexpectedOps) > 0 {
-		t.Errorf("expected no changes, got %s", unexpectedOps)
+		t.Errorf("expected no changes, got %s\n%s", unexpectedOps, preview.StdOut)
 	}
 }
 
@@ -26,6 +26,6 @@ func HasNoDeletes(t *testing.T, preview auto.PreviewResult) {
 	unexpectedOps := convertedMap.WhereOpEquals(apitype.OpDelete, apitype.OpDeleteReplaced, apitype.OpReplace)
 
 	if len(*unexpectedOps) > 0 {
-		t.Errorf("expected no changes, got %s", unexpectedOps)
+		t.Errorf("expected no changes, got %s\n%s", unexpectedOps, preview.StdOut)
 	}
 }

--- a/pulumitest/assertup/asserts.go
+++ b/pulumitest/assertup/asserts.go
@@ -16,7 +16,7 @@ func HasNoChanges(t *testing.T, up auto.UpResult) {
 	unexpectedOps := summary.WhereOpNotEquals(apitype.OpSame)
 
 	if len(*unexpectedOps) > 0 {
-		t.Errorf("expected no changes, got %s", unexpectedOps)
+		t.Errorf("expected no changes, got %s\n%s", unexpectedOps, up.StdOut)
 	}
 }
 
@@ -28,6 +28,6 @@ func HasNoDeletes(t *testing.T, up auto.UpResult) {
 	unexpectedOps := summary.WhereOpEquals(apitype.OpDelete, apitype.OpDeleteReplaced, apitype.OpReplace)
 
 	if len(*unexpectedOps) > 0 {
-		t.Errorf("expected no changes, got %s", unexpectedOps)
+		t.Errorf("expected no changes, got %s\n%s", unexpectedOps, up.StdOut)
 	}
 }

--- a/pulumitest/convert.go
+++ b/pulumitest/convert.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/pulumi/providertest/pulumitest/opttest"
 )
 
 type ConvertResult struct {
@@ -16,7 +18,7 @@ type ConvertResult struct {
 
 // Convert a program to a given language.
 // It returns a new PulumiTest instance for the converted program which will be outputted into a temporary directory.
-func (a *PulumiTest) Convert(language string) ConvertResult {
+func (a *PulumiTest) Convert(language string, opts ...opttest.Option) ConvertResult {
 	a.t.Helper()
 
 	tempDir := a.t.TempDir()
@@ -35,12 +37,17 @@ func (a *PulumiTest) Convert(language string) ConvertResult {
 		a.t.Fatalf("failed to convert directory: %s\n%s", err, out)
 	}
 
+	options := a.options.Copy()
+	for _, opt := range opts {
+		opt.Apply(options)
+	}
+
 	return ConvertResult{
 		PulumiTest: &PulumiTest{
 			t:       a.t,
 			ctx:     a.ctx,
 			source:  targetDir,
-			options: a.options,
+			options: options,
 		},
 		Output: string(out),
 	}

--- a/pulumitest/newStack.go
+++ b/pulumitest/newStack.go
@@ -56,6 +56,11 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...auto.LocalWorkspaceOpti
 		env["PULUMI_DEBUG_PROVIDERS"] = providers.GetDebugProvidersEnv(providerPorts)
 	}
 
+	// Apply custom env last to allow overriding any of the above.
+	for k, v := range options.CustomEnv {
+		env[k] = v
+	}
+
 	stackOpts := []auto.LocalWorkspaceOption{
 		auto.EnvVars(env),
 	}

--- a/pulumitest/opttest/opttest.go
+++ b/pulumitest/opttest/opttest.go
@@ -7,6 +7,28 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 )
 
+// StackName sets the default stack name to use when running the program under test.
+func StackName(name string) Option {
+	return optionFunc(func(o *Options) {
+		o.StackName = name
+	})
+}
+
+// SkipInstall skips running `pulumi install` before running the program under test.
+func SkipInstall() Option {
+	return optionFunc(func(o *Options) {
+		o.SkipInstall = true
+	})
+}
+
+// SkipStackCreate skips creating the stack before running the program under test.
+// A stack will have to be created manually before running the program under test.
+func SkipStackCreate() Option {
+	return optionFunc(func(o *Options) {
+		o.SkipStackCreate = true
+	})
+}
+
 // TestInPlace will run the program under test from its current location, rather than firstly copying to a temporary directory.
 func TestInPlace() Option {
 	return optionFunc(func(o *Options) {
@@ -108,6 +130,9 @@ func WorkspaceOptions(opts ...auto.LocalWorkspaceOption) Option {
 }
 
 type Options struct {
+	StackName             string
+	SkipInstall           bool
+	SkipStackCreate       bool
 	TestInPlace           bool
 	ConfigPassphrase      string
 	ProviderFactories     map[providers.ProviderName]providers.ProviderFactory
@@ -146,11 +171,13 @@ func (o *Options) Copy() *Options {
 }
 
 var defaultConfigPassphrase string = "correct horse battery staple"
+var defaultStackName string = "test"
 
 // Defaults sets all options back to their defaults.
 // This can be useful when using CopyToTempDir or Convert but not wanting to inherit any options from the previous PulumiTest.
 func Defaults() Option {
 	return optionFunc(func(o *Options) {
+		o.StackName = defaultStackName
 		o.TestInPlace = false
 		o.ConfigPassphrase = defaultConfigPassphrase
 		o.ProviderFactories = make(map[providers.ProviderName]providers.ProviderFactory)

--- a/pulumitest/opttest/opttest.go
+++ b/pulumitest/opttest/opttest.go
@@ -52,6 +52,16 @@ func LocalProviderPath(name string, path ...string) Option {
 	})
 }
 
+func DownloadProviderVersion(name, version string) Option {
+	return optionFunc(func(o *Options) {
+		binaryPath, err := providers.DownloadPluginBinary(name, version)
+		if err != nil {
+			panic(err)
+		}
+		o.ProviderPluginPaths[name] = binaryPath
+	})
+}
+
 // YarnLink specifies packages which are linked via `yarn link` and should be used when running the program under test.
 // Each package is called with `yarn link <package>` on stack creation.
 func YarnLink(packages ...string) Option {

--- a/pulumitest/opttest/opttest.go
+++ b/pulumitest/opttest/opttest.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pulumi/providertest/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/deepcopy"
 )
 
 // StackName sets the default stack name to use when running the program under test.
@@ -146,27 +147,7 @@ type Options struct {
 
 // Copy creates a deep copy of the current options.
 func (o *Options) Copy() *Options {
-	newOptions := *o
-	newOptions.ProviderFactories = make(map[providers.ProviderName]providers.ProviderFactory)
-	for k, v := range o.ProviderFactories {
-		newOptions.ProviderFactories[k] = v
-	}
-	newOptions.ProviderPluginPaths = make(map[string]string)
-	for k, v := range o.ProviderPluginPaths {
-		newOptions.ProviderPluginPaths[k] = v
-	}
-	newOptions.YarnLinks = make([]string, len(o.YarnLinks))
-	copy(newOptions.YarnLinks, o.YarnLinks)
-	newOptions.GoModReplacements = make(map[string]string)
-	for k, v := range o.GoModReplacements {
-		newOptions.GoModReplacements[k] = v
-	}
-	newOptions.CustomEnv = make(map[string]string)
-	for k, v := range o.CustomEnv {
-		newOptions.CustomEnv[k] = v
-	}
-	newOptions.ExtraWorkspaceOptions = make([]auto.LocalWorkspaceOption, len(o.ExtraWorkspaceOptions))
-	copy(newOptions.ExtraWorkspaceOptions, o.ExtraWorkspaceOptions)
+	newOptions := deepcopy.Copy(*o).(Options)
 	return &newOptions
 }
 

--- a/pulumitest/opttest/opttest.go
+++ b/pulumitest/opttest/opttest.go
@@ -109,16 +109,54 @@ type Options struct {
 	ExtraWorkspaceOptions []auto.LocalWorkspaceOption
 }
 
+// Copy creates a deep copy of the current options.
+func (o *Options) Copy() *Options {
+	newOptions := *o
+	newOptions.ProviderFactories = make(map[providers.ProviderName]providers.ProviderFactory)
+	for k, v := range o.ProviderFactories {
+		newOptions.ProviderFactories[k] = v
+	}
+	newOptions.ProviderPluginPaths = make(map[string]string)
+	for k, v := range o.ProviderPluginPaths {
+		newOptions.ProviderPluginPaths[k] = v
+	}
+	newOptions.YarnLinks = make([]string, len(o.YarnLinks))
+	copy(newOptions.YarnLinks, o.YarnLinks)
+	newOptions.GoModReplacements = make(map[string]string)
+	for k, v := range o.GoModReplacements {
+		newOptions.GoModReplacements[k] = v
+	}
+	newOptions.CustomEnv = make(map[string]string)
+	for k, v := range o.CustomEnv {
+		newOptions.CustomEnv[k] = v
+	}
+	newOptions.ExtraWorkspaceOptions = make([]auto.LocalWorkspaceOption, len(o.ExtraWorkspaceOptions))
+	copy(newOptions.ExtraWorkspaceOptions, o.ExtraWorkspaceOptions)
+	return &newOptions
+}
+
 var defaultConfigPassphrase string = "correct horse battery staple"
 
+// Defaults sets all options back to their defaults.
+// This can be useful when using CopyToTempDir or Convert but not wanting to inherit any options from the previous PulumiTest.
+func Defaults() Option {
+	return optionFunc(func(o *Options) {
+		o.TestInPlace = false
+		o.ConfigPassphrase = defaultConfigPassphrase
+		o.ProviderFactories = make(map[providers.ProviderName]providers.ProviderFactory)
+		o.ProviderPluginPaths = make(map[string]string)
+		o.UseAmbientBackend = false
+		o.YarnLinks = []string{}
+		o.GoModReplacements = make(map[string]string)
+		o.CustomEnv = make(map[string]string)
+		o.ExtraWorkspaceOptions = []auto.LocalWorkspaceOption{}
+	})
+}
+
 func DefaultOptions() *Options {
-	return &Options{
-		ConfigPassphrase:    defaultConfigPassphrase,
-		ProviderFactories:   make(map[providers.ProviderName]providers.ProviderFactory),
-		ProviderPluginPaths: make(map[string]string),
-		GoModReplacements:   make(map[string]string),
-		CustomEnv:           make(map[string]string),
-	}
+	o := &Options{}
+	Defaults().Apply(o)
+	return o
 }
 
 type Option interface {

--- a/pulumitest/opttest/opttest.go
+++ b/pulumitest/opttest/opttest.go
@@ -179,6 +179,8 @@ func Defaults() Option {
 	return optionFunc(func(o *Options) {
 		o.StackName = defaultStackName
 		o.TestInPlace = false
+		o.SkipInstall = false
+		o.SkipStackCreate = false
 		o.ConfigPassphrase = defaultConfigPassphrase
 		o.ProviderFactories = make(map[providers.ProviderName]providers.ProviderFactory)
 		o.ProviderPluginPaths = make(map[string]string)

--- a/pulumitest/pulumiTest.go
+++ b/pulumitest/pulumiTest.go
@@ -16,6 +16,11 @@ type PulumiTest struct {
 	currentStack *auto.Stack
 }
 
+// NewPulumiTest creates a new PulumiTest instance.
+// By default it will:
+// 1. Copy the source to a temporary directory.
+// 2. Install dependencies.
+// 3. Create a new stack called "test" with state stored to a local temporary directory and a fixed passphrase for encryption.
 func NewPulumiTest(t *testing.T, source string, opts ...opttest.Option) *PulumiTest {
 	var ctx context.Context
 	var cancel context.CancelFunc
@@ -38,21 +43,31 @@ func NewPulumiTest(t *testing.T, source string, opts ...opttest.Option) *PulumiT
 	if !options.TestInPlace {
 		return pt.CopyToTempDir()
 	}
+	if !options.SkipInstall {
+		pt.Install()
+	}
+	if !options.SkipStackCreate {
+		pt.NewStack(options.StackName)
+	}
 	return pt
 }
 
+// Source returns the current source directory.
 func (a *PulumiTest) Source() string {
 	return a.source
 }
 
+// T returns the current testing.T instance.
 func (a *PulumiTest) T() *testing.T {
 	return a.t
 }
 
+// Context returns the current context.Context instance used for automation API calls.
 func (a *PulumiTest) Context() context.Context {
 	return a.ctx
 }
 
+// CurrentStack returns the last stack that was created or nil if no stack has been created yet.
 func (a *PulumiTest) CurrentStack() *auto.Stack {
 	return a.currentStack
 }

--- a/pulumitest/pulumiTest.go
+++ b/pulumitest/pulumiTest.go
@@ -53,20 +53,6 @@ func (a *PulumiTest) Context() context.Context {
 	return a.ctx
 }
 
-func (a *PulumiTest) WithSource(source string) *PulumiTest {
-	a.t.Helper()
-	a.source = source
-	return a
-}
-
 func (a *PulumiTest) CurrentStack() *auto.Stack {
 	return a.currentStack
-}
-
-func (a *PulumiTest) WithOptions(opts ...opttest.Option) *PulumiTest {
-	a.t.Helper()
-	for _, opt := range opts {
-		opt.Apply(a.options)
-	}
-	return a
 }


### PR DESCRIPTION
## Make PulumiTest immutable

- Avoid accidental mutation of the options for a source test instance after copying to a new directory.
- Remove With... options on PulumiTest to avoid unclear mutation semantics.
- Deep copy the options on copying to a new temp directory.
- Add opttest.Default() option for resetting all previously set options.
- Add CopyTo(dir) for specifying a custom directory to copy the program to (and rename source to copy.go).
- Add the setting of additional options during CopyTo* and Convert methods.

## Install and create "test" stack by default

These two steps are almost always needed to be run before being able to start the test.
- Add extra docs to highlight these defaults.
- Add options to opt out of this default behaviour.

## Minor fixes

- Fix applying custom env
- Add opttest.DownloadProviderVersion
- Print console output for failing operation asserts