### PR TITLE
Add Preview provider upgrade test

### DIFF
--- a/optproviderupgrade/optproviderupgrade.go
+++ b/optproviderupgrade/optproviderupgrade.go
@@ -1,0 +1,49 @@
+package optproviderupgrade
+
+import (
+	"github.com/pulumi/providertest/pulumitest/opttest"
+)
+
+// DisableAttach will configure the provider binary in the program's Pulumi.yaml rather than attaching the running provider.
+func DisableAttach() PreviewProviderUpgradeOpt {
+	return optionFunc(func(o *PreviewProviderUpgradeOptions) {
+		o.DisableAttach = true
+	})
+}
+
+// BaselineOptions sets the options to use when creating the baseline stack.
+func BaselineOpts(opts ...opttest.Option) PreviewProviderUpgradeOpt {
+	return optionFunc(func(o *PreviewProviderUpgradeOptions) {
+		o.BaselineOpts = opts
+	})
+}
+
+// CacheDir sets the path to the directory to use for caching the stack state and grpc log.
+// Use "." to use the current working directory.
+// The path can contain the following placeholders:
+// - {programName}: the name of the program under test based on the program's directory name
+// - {baselineVersion}: the version of the provider used for the baseline
+func CacheDir(pathTemplate ...string) PreviewProviderUpgradeOpt {
+	if len(pathTemplate) == 0 {
+		panic("CacheDir requires a path template")
+	}
+	return optionFunc(func(o *PreviewProviderUpgradeOptions) {
+		o.CacheDirTemplate = pathTemplate
+	})
+}
+
+type PreviewProviderUpgradeOptions struct {
+	CacheDirTemplate []string
+	DisableAttach    bool
+	BaselineOpts     []opttest.Option
+}
+
+type PreviewProviderUpgradeOpt interface {
+	Apply(*PreviewProviderUpgradeOptions)
+}
+
+type optionFunc func(*PreviewProviderUpgradeOptions)
+
+func (o optionFunc) Apply(opts *PreviewProviderUpgradeOptions) {
+	o(opts)
+}

--- a/optproviderupgrade/optproviderupgrade.go
+++ b/optproviderupgrade/optproviderupgrade.go
@@ -11,6 +11,12 @@ func DisableAttach() PreviewProviderUpgradeOpt {
 	})
 }
 
+// ProgramName is replaced with the name of the program under test based on the program's directory name.
+var ProgramName string = "{programName}"
+
+// BaselineVersion is replaced with the version of the provider used for the baseline.
+var BaselineVersion string = "{baselineVersion}"
+
 // BaselineOptions sets the options to use when creating the baseline stack.
 func BaselineOpts(opts ...opttest.Option) PreviewProviderUpgradeOpt {
 	return optionFunc(func(o *PreviewProviderUpgradeOptions) {
@@ -19,16 +25,16 @@ func BaselineOpts(opts ...opttest.Option) PreviewProviderUpgradeOpt {
 }
 
 // CacheDir sets the path to the directory to use for caching the stack state and grpc log.
-// Use "." to use the current working directory.
 // The path can contain the following placeholders:
+//
 // - {programName}: the name of the program under test based on the program's directory name
+//
 // - {baselineVersion}: the version of the provider used for the baseline
-func CacheDir(pathTemplate ...string) PreviewProviderUpgradeOpt {
-	if len(pathTemplate) == 0 {
-		panic("CacheDir requires a path template")
-	}
+//
+// Calculated path elements are joined with filepath.Join.
+func CacheDir(elem ...string) PreviewProviderUpgradeOpt {
 	return optionFunc(func(o *PreviewProviderUpgradeOptions) {
-		o.CacheDirTemplate = pathTemplate
+		o.CacheDirTemplate = elem
 	})
 }
 
@@ -40,6 +46,12 @@ type PreviewProviderUpgradeOptions struct {
 
 type PreviewProviderUpgradeOpt interface {
 	Apply(*PreviewProviderUpgradeOptions)
+}
+
+func Defaults() PreviewProviderUpgradeOptions {
+	return PreviewProviderUpgradeOptions{
+		CacheDirTemplate: []string{"testdata", "recorded", "TestProviderUpgrade", ProgramName, BaselineVersion},
+	}
 }
 
 type optionFunc func(*PreviewProviderUpgradeOptions)

--- a/previewProviderUpgrade.go
+++ b/previewProviderUpgrade.go
@@ -14,7 +14,7 @@ import (
 // Uses a default cache directory of "testdata/recorded/TestProviderUpgrade/{programName}/{baselineVersion}".
 func PreviewProviderUpgrade(pulumiTest *pulumitest.PulumiTest, providerName string, baselineVersion string, opts ...optproviderupgrade.PreviewProviderUpgradeOpt) auto.PreviewResult {
 	pulumiTest.T().Helper()
-	options := optproviderupgrade.PreviewProviderUpgradeOptions{}
+	options := optproviderupgrade.Defaults()
 	for _, opt := range opts {
 		opt.Apply(&options)
 	}
@@ -35,15 +35,12 @@ func PreviewProviderUpgrade(pulumiTest *pulumitest.PulumiTest, providerName stri
 }
 
 func getCacheDir(options optproviderupgrade.PreviewProviderUpgradeOptions, programName string, baselineVersion string) string {
-	if len(options.CacheDirTemplate) == 0 {
-		options.CacheDirTemplate = []string{"testdata", "recorded", "TestProviderUpgrade", "{programName}", "{baselineVersion}"}
-	}
 	var cacheDir string
 	for _, pathTemplateElement := range options.CacheDirTemplate {
 		switch pathTemplateElement {
-		case "{programName}":
+		case optproviderupgrade.ProgramName:
 			cacheDir = filepath.Join(cacheDir, programName)
-		case "{baselineVersion}":
+		case optproviderupgrade.BaselineVersion:
 			cacheDir = filepath.Join(cacheDir, baselineVersion)
 		default:
 			cacheDir = filepath.Join(cacheDir, pathTemplateElement)

--- a/previewProviderUpgrade.go
+++ b/previewProviderUpgrade.go
@@ -1,0 +1,53 @@
+package providertest
+
+import (
+	"path/filepath"
+
+	"github.com/pulumi/providertest/optproviderupgrade"
+	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/pulumitest/optrun"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto"
+)
+
+// PreviewProviderUpgrade captures the state of a stack from a baseline provider configuration, then previews the stack
+// with the current provider configuration.
+// Uses a default cache directory of "testdata/recorded/TestProviderUpgrade/{programName}/{baselineVersion}".
+func PreviewProviderUpgrade(pulumiTest *pulumitest.PulumiTest, providerName string, baselineVersion string, opts ...optproviderupgrade.PreviewProviderUpgradeOpt) auto.PreviewResult {
+	pulumiTest.T().Helper()
+	options := optproviderupgrade.PreviewProviderUpgradeOptions{}
+	for _, opt := range opts {
+		opt.Apply(&options)
+	}
+	programName := filepath.Base(pulumiTest.Source())
+	cacheDir := getCacheDir(options, programName, baselineVersion)
+	pulumiTest.Run(
+		func(test *pulumitest.PulumiTest) {
+			test.T().Helper()
+			test.Up()
+			grptLog := test.GrpcLog()
+			grpcLogPath := filepath.Join(cacheDir, "grpc.json")
+			test.T().Logf("writing grpc log to %s", grpcLogPath)
+			grptLog.WriteTo(grpcLogPath)
+		},
+		optrun.WithCache(filepath.Join(cacheDir, "stack.json")),
+		optrun.WithOpts(options.BaselineOpts...))
+	return pulumiTest.Preview()
+}
+
+func getCacheDir(options optproviderupgrade.PreviewProviderUpgradeOptions, programName string, baselineVersion string) string {
+	if len(options.CacheDirTemplate) == 0 {
+		options.CacheDirTemplate = []string{"testdata", "recorded", "TestProviderUpgrade", "{programName}", "{baselineVersion}"}
+	}
+	var cacheDir string
+	for _, pathTemplateElement := range options.CacheDirTemplate {
+		switch pathTemplateElement {
+		case "{programName}":
+			cacheDir = filepath.Join(cacheDir, programName)
+		case "{baselineVersion}":
+			cacheDir = filepath.Join(cacheDir, baselineVersion)
+		default:
+			cacheDir = filepath.Join(cacheDir, pathTemplateElement)
+		}
+	}
+	return cacheDir
+}

--- a/previewProviderUpgrade_test.go
+++ b/previewProviderUpgrade_test.go
@@ -1,0 +1,30 @@
+package providertest_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/providertest"
+	"github.com/pulumi/providertest/optproviderupgrade"
+	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/pulumitest/assertpreview"
+	"github.com/pulumi/providertest/pulumitest/opttest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPreviewUpgradeCached(t *testing.T) {
+	cacheDir := t.TempDir()
+	test := pulumitest.NewPulumiTest(t, filepath.Join("pulumitest", "testdata", "yaml_program"),
+		opttest.DownloadProviderVersion("random", "4.15.0"))
+
+	uncachedPreviewResult := providertest.PreviewProviderUpgrade(test, "random", "4.5.0",
+		optproviderupgrade.CacheDir(cacheDir, "{programName}", "{baselineVersion}"),
+		optproviderupgrade.DisableAttach())
+	assertpreview.HasNoReplacements(t, uncachedPreviewResult)
+	assertpreview.HasNoChanges(t, uncachedPreviewResult)
+
+	cachedPreviewResult := providertest.PreviewProviderUpgrade(test, "random", "4.5.0",
+		optproviderupgrade.CacheDir(cacheDir, "{programName}", "{baselineVersion}"),
+		optproviderupgrade.DisableAttach())
+	assert.Equal(t, uncachedPreviewResult, cachedPreviewResult, "expected uncached and cached preview to be the same")
+}

--- a/pulumitest/assertpreview/asserts.go
+++ b/pulumitest/assertpreview/asserts.go
@@ -29,3 +29,14 @@ func HasNoDeletes(t *testing.T, preview auto.PreviewResult) {
 		t.Errorf("expected no changes, got %s\n%s", unexpectedOps, preview.StdOut)
 	}
 }
+
+func HasNoReplacements(t *testing.T, preview auto.PreviewResult) {
+	t.Helper()
+
+	convertedMap := changesummary.ChangeSummary(preview.ChangeSummary)
+	unexpectedOps := convertedMap.WhereOpEquals(apitype.OpReplace, apitype.OpCreateReplacement, apitype.OpDeleteReplaced, apitype.OpDiscardReplaced, apitype.OpImportReplacement, apitype.OpReadReplacement)
+
+	if len(*unexpectedOps) > 0 {
+		t.Errorf("expected no replacements, got %s\n%s", unexpectedOps, preview.StdOut)
+	}
+}

--- a/pulumitest/assertup/asserts.go
+++ b/pulumitest/assertup/asserts.go
@@ -31,3 +31,14 @@ func HasNoDeletes(t *testing.T, up auto.UpResult) {
 		t.Errorf("expected no changes, got %s\n%s", unexpectedOps, up.StdOut)
 	}
 }
+
+func HasNoReplacements(t *testing.T, up auto.UpResult) {
+	t.Helper()
+
+	summary := changesummary.FromStringIntMap(*up.Summary.ResourceChanges)
+	unexpectedOps := summary.WhereOpEquals(apitype.OpReplace, apitype.OpCreateReplacement, apitype.OpDeleteReplaced, apitype.OpDiscardReplaced, apitype.OpImportReplacement, apitype.OpReadReplacement)
+
+	if len(*unexpectedOps) > 0 {
+		t.Errorf("expected no replacements, got %s\n%s", unexpectedOps, up.StdOut)
+	}
+}

--- a/pulumitest/run.go
+++ b/pulumitest/run.go
@@ -1,10 +1,12 @@
 package pulumitest
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pulumi/providertest/pulumitest/optrun"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -47,6 +49,20 @@ func (pulumiTest *PulumiTest) Run(execute func(test *PulumiTest), opts ...optrun
 			}
 		}
 		stackExport = &exportedStack
+	}
+	// Workaround: Previously recorded stack exports may contain randomised stack names which we need to fix before importing.
+	// This can be removed once all old snapshots have been regenerated.
+	stackName := pulumiTest.CurrentStack().Name()
+	fixedStack, err := fixupStackName(stackExport, stackName)
+	if err != nil {
+		pulumiTest.T().Fatalf("failed to fixup stack name: %v", err)
+	}
+	if fixedStack != stackExport {
+		pulumiTest.T().Logf("updating snapshot with fixed stack name: %s", stackName)
+		err = writeStackExport(options.CachePath, fixedStack, true /* overwrite */)
+		if err != nil {
+			pulumiTest.T().Fatalf("failed to write snapshot to %s: %v", options.CachePath, err)
+		}
 	}
 	pulumiTest.ImportStack(*stackExport)
 	return pulumiTest
@@ -92,4 +108,39 @@ func tryReadStackExport(path string) (*apitype.UntypedDeployment, error) {
 		return nil, fmt.Errorf("failed to unmarshal stack export at %s: %v", path, err)
 	}
 	return &stackExport, nil
+}
+
+func fixupStackName(stateFile *apitype.UntypedDeployment, newStackName string) (*apitype.UntypedDeployment, error) {
+	oldStackName, err := parseStackName(stateFile)
+	if err != nil {
+		return nil, err
+	}
+	if oldStackName == newStackName {
+		return stateFile, nil
+	}
+	newDeployment := bytes.ReplaceAll([]byte(stateFile.Deployment), []byte(oldStackName), []byte(newStackName))
+	newStateFile := *stateFile
+	newStateFile.Deployment = json.RawMessage(newDeployment)
+	return &newStateFile, nil
+}
+
+func parseStackName(state *apitype.UntypedDeployment) (string, error) {
+	type Deployment struct {
+		Resources []struct {
+			URN  string `json:"urn"`
+			Type string `json:"type"`
+		} `json:"resources"`
+	}
+	var deployment Deployment
+	err := json.Unmarshal([]byte(state.Deployment), &deployment)
+	if err != nil {
+		return "", err
+	}
+	var stackUrn string
+	for _, r := range deployment.Resources {
+		if r.Type == "pulumi:pulumi:Stack" {
+			stackUrn = r.URN
+		}
+	}
+	return strings.Split(stackUrn, ":")[2], nil
 }

--- a/pulumitest/run.go
+++ b/pulumitest/run.go
@@ -140,6 +140,7 @@ func parseStackName(state *apitype.UntypedDeployment) (string, error) {
 	for _, r := range deployment.Resources {
 		if r.Type == "pulumi:pulumi:Stack" {
 			stackUrn = r.URN
+			break
 		}
 	}
 	return strings.Split(stackUrn, ":")[2], nil

--- a/pulumitest/run_test.go
+++ b/pulumitest/run_test.go
@@ -53,4 +53,23 @@ func TestRunInIsolation(t *testing.T) {
 		assert.Equal(t, 1, cacheCalls, "expected cached method to be called exactly once")
 		assert.Equal(t, preview1.ChangeSummary, preview2.ChangeSummary, "expected uncached and cached preview to be the same")
 	})
+
+	t.Run("fix cached stack name", func(t *testing.T) {
+		cacheDir := t.TempDir()
+		cachePath := filepath.Join(cacheDir, "stack.yaml")
+
+		test1 := pulumitest.NewPulumiTest(t, filepath.Join("testdata", "yaml_program"), opttest.StackName("stack-1"))
+		test1.Run(func(test *pulumitest.PulumiTest) {
+			test.Up()
+		}, optrun.WithCache(cachePath))
+		preview1 := test1.Preview()
+		assertpreview.HasNoChanges(t, preview1)
+
+		test2 := pulumitest.NewPulumiTest(t, filepath.Join("testdata", "yaml_program"))
+		test2.Run(func(test *pulumitest.PulumiTest) {
+			test.Up()
+		}, optrun.WithCache(cachePath))
+		preview2 := test2.Preview()
+		assertpreview.HasNoChanges(t, preview2)
+	})
 }


### PR DESCRIPTION
Stacked on top of #49 and #50 

Implement simplified upgrade test which leverages the new test framework. Default cache paths should remain the same. 

This will perform a one-off fix-up of stack names on first run as stack names can now be a fixed value because tests should be storing state to local files which avoids name contention in the service.

This also adjusts the core options to represent all configured providers together. Therefore, re-configuring the same provider will overwrite the provider's previous configuration which is more predictable that potentially having both attachment and local binary paths set.

A typcial upgrade test will now look something like:

```go
test := pulumitest.NewPulumiTest(t, filepath.Join("path", "to", "program"),
  // Some local provider configuration
  )

previewResult := providertest.PreviewProviderUpgrade(test, "gcp", "1.2.3")
assertpreview.HasNoReplacements(t, previewResult)
assertpreview.HasNoChanges(t, previewResult)
```