### PR TITLE
Fix panic in AssertJSONMatchesPattern

### DIFF
--- a/replay/json_match.go
+++ b/replay/json_match.go
@@ -76,6 +76,7 @@ func AssertJSONMatchesPattern(
 			if len(aa) != len(pp) {
 				t.Errorf("[%s]: expected an array of length %d, but got %s",
 					path, len(pp), prettyJSON(t, a))
+				return
 			}
 			for i, pv := range pp {
 				av := aa[i]

--- a/replay/json_match.go
+++ b/replay/json_match.go
@@ -24,6 +24,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testingT interface {
+	assert.TestingT
+	require.TestingT
+}
+
 // Assert that a given JSON document structurally matches a pattern.
 //
 // The pattern language supports the following constructs:
@@ -34,6 +39,14 @@ import (
 // use {"\\": "*"} to match only the literal string "*".
 func AssertJSONMatchesPattern(
 	t *testing.T,
+	expectedPattern json.RawMessage,
+	actual json.RawMessage,
+) {
+	assertJSONMatchesPattern(t, expectedPattern, actual)
+}
+
+func assertJSONMatchesPattern(
+	t testingT,
 	expectedPattern json.RawMessage,
 	actual json.RawMessage,
 ) {
@@ -133,11 +146,11 @@ func AssertJSONMatchesPattern(
 	match("#", p, a)
 }
 
-func assertJSONEquals(t *testing.T, path string, expected, actual interface{}) {
+func assertJSONEquals(t testingT, path string, expected, actual interface{}) {
 	assert.Equalf(t, prettyJSON(t, expected), prettyJSON(t, actual), "at %s", path)
 }
 
-func prettyJSON(t *testing.T, msg interface{}) string {
+func prettyJSON(t testingT, msg interface{}) string {
 	bytes, err := json.MarshalIndent(msg, "", "  ")
 	assert.NoError(t, err)
 	return string(bytes)


### PR DESCRIPTION
Came across a panic in pulumi-tls. 

```
  panic: runtime error: index out of range [1] with length 1 [recovered]
  	panic: runtime error: index out of range [1] with length 1
```

Simple bug fix - when matching an array against the pattern, if the array lengths don't match we're done. No need to compare elements. Alternatively we could compare elements but check for out-of-bounds/missing elements, but this should be good enough for now I think. 