### PR TITLE
Backport replay additions from pulumi-terraform-bridge

### DIFF
--- a/replay/json_match.go
+++ b/replay/json_match.go
@@ -18,24 +18,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type jsonMatchOptions struct {
-	UnorderedArrayPaths map[string]bool
-}
-
-type JSONMatchOption func(*jsonMatchOptions)
-
-func WithUnorderedArrayPaths(unorderedArrayPaths map[string]bool) JSONMatchOption {
-	return func(opts *jsonMatchOptions) {
-		opts.UnorderedArrayPaths = unorderedArrayPaths
-	}
-}
 
 type testingT interface {
 	assert.TestingT
@@ -54,23 +41,16 @@ func AssertJSONMatchesPattern(
 	t *testing.T,
 	expectedPattern json.RawMessage,
 	actual json.RawMessage,
-	opts ...JSONMatchOption,
 ) {
-	assertJSONMatchesPattern(t, expectedPattern, actual, opts...)
+	assertJSONMatchesPattern(t, expectedPattern, actual)
 }
 
 func assertJSONMatchesPattern(
 	t testingT,
 	expectedPattern json.RawMessage,
 	actual json.RawMessage,
-	opts ...JSONMatchOption,
 ) {
 	var p, a interface{}
-
-	options := jsonMatchOptions{}
-	for _, opt := range opts {
-		opt(&options)
-	}
 
 	if err := json.Unmarshal(expectedPattern, &p); err != nil {
 		require.NoError(t, err)
@@ -109,14 +89,6 @@ func assertJSONMatchesPattern(
 				t.Errorf("[%s]: expected an array of length %d, but got %s",
 					path, len(pp), prettyJSON(t, a))
 				return
-			}
-			if options.UnorderedArrayPaths[path] {
-				sort.SliceStable(aa, func(i, j int) bool {
-					return strings.Compare(
-						fmt.Sprintf("%v", aa[i]),
-						fmt.Sprintf("%v", aa[j]),
-					) < 0
-				})
 			}
 			for i, pv := range pp {
 				av := aa[i]

--- a/replay/json_match.go
+++ b/replay/json_match.go
@@ -17,7 +17,6 @@ package replay
 import (
 	"encoding/json"
 	"fmt"
-	"q"
 	"sort"
 	"strings"
 	"testing"
@@ -111,7 +110,6 @@ func assertJSONMatchesPattern(
 					path, len(pp), prettyJSON(t, a))
 				return
 			}
-			q.Q(path, options.UnorderedArrayPaths)
 			if options.UnorderedArrayPaths[path] {
 				sort.SliceStable(aa, func(i, j int) bool {
 					return strings.Compare(

--- a/replay/json_match_test.go
+++ b/replay/json_match_test.go
@@ -29,6 +29,23 @@ func TestJsonMatch(t *testing.T) {
 	AssertJSONMatchesPattern(t, []byte(`{"\\": "*"}`), []byte(`"*"`))
 	AssertJSONMatchesPattern(t, []byte(`[1, "*", 3]`), []byte(`[1, 2, 3]`))
 	AssertJSONMatchesPattern(t, []byte(`{"foo": "*", "bar": 3}`), []byte(`{"foo": 1, "bar": 3}`))
+	AssertJSONMatchesPattern(t, []byte(`[1, 2, 3]`), []byte(`[1, 3, 2]`),
+		WithUnorderedArrayPaths(map[string]bool{"#": true}))
+	AssertJSONMatchesPattern(t,
+		[]byte(`[{"key1":"val"}, {"key2":"val"}]`),
+		[]byte(`[{"key2":"val"}, {"key1":"val"}]`),
+		WithUnorderedArrayPaths(map[string]bool{"#": true}),
+	)
+	AssertJSONMatchesPattern(t,
+		[]byte(`[{"key":"val1"}, {"key":"val2"}]`),
+		[]byte(`[{"key":"val2"}, {"key":"val1"}]`),
+		WithUnorderedArrayPaths(map[string]bool{"#": true}),
+	)
+	AssertJSONMatchesPattern(t,
+		[]byte(`{"arr":[{"key":"val1"}, {"key":"val2"}]}`),
+		[]byte(`{"arr":[{"key":"val2"}, {"key":"val1"}]}`),
+		WithUnorderedArrayPaths(map[string]bool{`#["arr"]`: true}),
+	)
 }
 
 func TestJsonListLengthMistmatch(t *testing.T) {

--- a/replay/json_match_test.go
+++ b/replay/json_match_test.go
@@ -29,23 +29,6 @@ func TestJsonMatch(t *testing.T) {
 	AssertJSONMatchesPattern(t, []byte(`{"\\": "*"}`), []byte(`"*"`))
 	AssertJSONMatchesPattern(t, []byte(`[1, "*", 3]`), []byte(`[1, 2, 3]`))
 	AssertJSONMatchesPattern(t, []byte(`{"foo": "*", "bar": 3}`), []byte(`{"foo": 1, "bar": 3}`))
-	AssertJSONMatchesPattern(t, []byte(`[1, 2, 3]`), []byte(`[1, 3, 2]`),
-		WithUnorderedArrayPaths(map[string]bool{"#": true}))
-	AssertJSONMatchesPattern(t,
-		[]byte(`[{"key1":"val"}, {"key2":"val"}]`),
-		[]byte(`[{"key2":"val"}, {"key1":"val"}]`),
-		WithUnorderedArrayPaths(map[string]bool{"#": true}),
-	)
-	AssertJSONMatchesPattern(t,
-		[]byte(`[{"key":"val1"}, {"key":"val2"}]`),
-		[]byte(`[{"key":"val2"}, {"key":"val1"}]`),
-		WithUnorderedArrayPaths(map[string]bool{"#": true}),
-	)
-	AssertJSONMatchesPattern(t,
-		[]byte(`{"arr":[{"key":"val1"}, {"key":"val2"}]}`),
-		[]byte(`{"arr":[{"key":"val2"}, {"key":"val1"}]}`),
-		WithUnorderedArrayPaths(map[string]bool{`#["arr"]`: true}),
-	)
 }
 
 func TestJsonListLengthMistmatch(t *testing.T) {

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -1,0 +1,123 @@
+package replay
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	"github.com/pulumi/providertest/providers"
+)
+
+// When testing methods that return CheckFailure lists, the tests do not want to care about the
+// ordering of the individual failures. These tests should not or fail when providers change the
+// ordering or exhibit non-determinism. To accomplish this, ensure that Replay sorts CheckFailures
+// before matching against the expected response.
+func TestReplayNormalizesCheckFailureOrder(t *testing.T) {
+	failures := []*pulumirpc.CheckFailure{
+		{Property: "B", Reason: "B-failed"},
+		{Property: "A", Reason: "A-failed"},
+	}
+
+	p, err := providers.NewProviderMock(context.Background(), providers.ProviderMocks{
+		CheckConfig: func(ctx context.Context, in *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
+			return &pulumirpc.CheckResponse{Failures: failures}, nil
+		},
+		Check: func(ctx context.Context, in *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
+			return &pulumirpc.CheckResponse{Failures: failures}, nil
+		},
+		Invoke: func(ctx context.Context, in *pulumirpc.InvokeRequest) (*pulumirpc.InvokeResponse, error) {
+			return &pulumirpc.InvokeResponse{Failures: failures}, nil
+		},
+		Call: func(ctx context.Context, in *pulumirpc.CallRequest) (*pulumirpc.CallResponse, error) {
+			return &pulumirpc.CallResponse{Failures: failures}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	Replay(t, p, `
+	{
+	  "method": "/pulumirpc.ResourceProvider/Check",
+	  "request": {
+	    "urn": "u",
+	    "news": {}
+	  },
+	  "response": {
+	    "failures": [
+	      {
+		"property": "A",
+		"reason": "A-failed"
+	      },
+	      {
+		"property": "B",
+		"reason": "B-failed"
+	      }
+	    ]
+	  }
+	}`)
+
+	Replay(t, p, `
+	{
+	  "method": "/pulumirpc.ResourceProvider/CheckConfig",
+	  "request": {
+	    "urn": "u",
+	    "news": {}
+	  },
+	  "response": {
+	    "failures": [
+	      {
+		"property": "A",
+		"reason": "A-failed"
+	      },
+	      {
+		"property": "B",
+		"reason": "B-failed"
+	      }
+	    ]
+	  }
+	}`)
+
+	Replay(t, p, `
+	{
+	  "method": "/pulumirpc.ResourceProvider/Invoke",
+	  "request": {
+	    "tok": "t",
+	    "args": {}
+	  },
+	  "response": {
+	    "failures": [
+	      {
+		"property": "A",
+		"reason": "A-failed"
+	      },
+	      {
+		"property": "B",
+		"reason": "B-failed"
+	      }
+	    ]
+	  }
+	}`)
+
+	Replay(t, p, `
+	{
+	  "method": "/pulumirpc.ResourceProvider/Call",
+	  "request": {
+	    "tok": "t",
+	    "args": {}
+	  },
+	  "response": {
+	    "failures": [
+	      {
+		"property": "A",
+		"reason": "A-failed"
+	      },
+	      {
+		"property": "B",
+		"reason": "B-failed"
+	      }
+	    ]
+	  }
+	}`)
+}


### PR DESCRIPTION
Alternative to https://github.com/pulumi/providertest/pull/59

The motivation is to deprecate the replay module in pulumi-terraform-bridge in favor of a Go package here under generic providertest, and backport edits that happened in pulumi-terraform-bridge to this new home.

Unlike #59 two small things:

- trying not to expose the match options but solve the CheckFailure ordering on semantic level
- trying to make Errors compatible with gRPC log capture format []string