### PR TITLE
Use absolute file path for local provider paths

### DIFF
--- a/pulumitest/install.go
+++ b/pulumitest/install.go
@@ -13,7 +13,7 @@ func (a *PulumiTest) Install() string {
 	cmd.Dir = a.source
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		a.t.Fatalf("failed to installing packages and plugins: %s\n%s", err, out)
+		a.t.Fatalf("failed to install packages and plugins: %s\n%s", err, out)
 	}
 	return string(out)
 }

--- a/pulumitest/newStack.go
+++ b/pulumitest/newStack.go
@@ -100,11 +100,16 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 		}
 		sort.Strings(providerPluginNames)
 		for _, name := range providerPluginNames {
-			path := providerPluginPaths[providers.ProviderName(name)]
+			relPath := providerPluginPaths[providers.ProviderName(name)]
+			absPath, err := filepath.Abs(relPath)
+			if err != nil {
+				pt.t.Fatalf("failed to get absolute path for %s: %s", relPath, err)
+			}
+
 			found := false
 			for _, provider := range providerPlugins {
 				if provider.Name == name {
-					provider.Path = path
+					provider.Path = absPath
 					found = true
 					break
 				}
@@ -112,7 +117,7 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 			if !found {
 				providerPlugins = append(providerPlugins, workspace.PluginOptions{
 					Name: name,
-					Path: path,
+					Path: absPath,
 				})
 			}
 		}


### PR DESCRIPTION
A simple fix for the `LocalProviderPath` option, the path should be made absolute in the resultant `Pulumi.yaml` configuration block.

Repro: given a test case that overrides the local provider path:
```go
test := pulumitest.NewPulumiTest(t, "helm-release-unknowns", opttest.LocalProviderPath("kubernetes", "../../../bin"))
```

The program fails with:
```
    /Users/eronwright/Pulumi/pulumi-kubernetes/tests/sdk/nodejs/helm_test.go:33: failed to installing packages and plugins: exit status 255
        error: parsing plugin options for 'kubernetes': no folder at path '../../../bin'
```

I believe this is because Pulumi attempts to resolve the provided path using the workspace directory. As is done with go.mod replacements, the test framework must resolve the path more eagerly.
