### PR TITLE
Clear the gRPC log before running a deployment

### DIFF
--- a/pulumitest/destroy.go
+++ b/pulumitest/destroy.go
@@ -13,6 +13,7 @@ func (a *PulumiTest) Destroy(opts ...optdestroy.Option) auto.DestroyResult {
 	if a.currentStack == nil {
 		a.t.Fatal("no current stack")
 	}
+	a.ClearGrpcLog()
 	result, err := a.currentStack.Destroy(a.ctx, opts...)
 	if err != nil {
 		a.t.Fatalf("failed to destroy: %s", err)

--- a/pulumitest/destroy.go
+++ b/pulumitest/destroy.go
@@ -13,7 +13,9 @@ func (a *PulumiTest) Destroy(opts ...optdestroy.Option) auto.DestroyResult {
 	if a.currentStack == nil {
 		a.t.Fatal("no current stack")
 	}
-	a.ClearGrpcLog()
+	if !a.options.DisableGrpcLog {
+		a.ClearGrpcLog()
+	}
 	result, err := a.currentStack.Destroy(a.ctx, opts...)
 	if err != nil {
 		a.t.Fatalf("failed to destroy: %s", err)

--- a/pulumitest/grpcLog.go
+++ b/pulumitest/grpcLog.go
@@ -1,6 +1,10 @@
 package pulumitest
 
-import "github.com/pulumi/providertest/grpclog"
+import (
+	"os"
+
+	"github.com/pulumi/providertest/grpclog"
+)
 
 // GrpcLog reads the gRPC log for the current stack based on the PULUMI_DEBUG_GRPC env var.
 func (pt *PulumiTest) GrpcLog() *grpclog.GrpcLog {
@@ -22,4 +26,16 @@ func (pt *PulumiTest) GrpcLog() *grpclog.GrpcLog {
 		pt.t.Fatalf("failed to load grpc log: %s", err)
 	}
 	return log
+}
+
+// ClearGrpcLog clears the gRPC log for the current stack based on the PULUMI_DEBUG_GRPC env var.
+func (pt *PulumiTest) ClearGrpcLog() {
+	env := pt.CurrentStack().Workspace().GetEnvVars()
+	if env == nil || env["PULUMI_DEBUG_GRPC"] == "" {
+		pt.t.Log("can't clear gRPC log: PULUMI_DEBUG_GRPC env var not set")
+		return
+	}
+	if err := os.RemoveAll(env["PULUMI_DEBUG_GRPC"]); err != nil {
+		pt.t.Fatalf("failed to clear gRPC log: %s", err)
+	}
 }

--- a/pulumitest/grpcLog.go
+++ b/pulumitest/grpcLog.go
@@ -32,7 +32,6 @@ func (pt *PulumiTest) GrpcLog() *grpclog.GrpcLog {
 func (pt *PulumiTest) ClearGrpcLog() {
 	env := pt.CurrentStack().Workspace().GetEnvVars()
 	if env == nil || env["PULUMI_DEBUG_GRPC"] == "" {
-		pt.t.Log("can't clear gRPC log: PULUMI_DEBUG_GRPC env var not set")
 		return
 	}
 	if err := os.RemoveAll(env["PULUMI_DEBUG_GRPC"]); err != nil {

--- a/pulumitest/preview.go
+++ b/pulumitest/preview.go
@@ -13,7 +13,9 @@ func (a *PulumiTest) Preview(opts ...optpreview.Option) auto.PreviewResult {
 	if a.currentStack == nil {
 		a.t.Fatal("no current stack")
 	}
-	a.ClearGrpcLog()
+	if !a.options.DisableGrpcLog {
+		a.ClearGrpcLog()
+	}
 	result, err := a.currentStack.Preview(a.ctx, opts...)
 	if err != nil {
 		a.t.Fatalf("failed to preview update: %s", err)

--- a/pulumitest/preview.go
+++ b/pulumitest/preview.go
@@ -13,6 +13,7 @@ func (a *PulumiTest) Preview(opts ...optpreview.Option) auto.PreviewResult {
 	if a.currentStack == nil {
 		a.t.Fatal("no current stack")
 	}
+	a.ClearGrpcLog()
 	result, err := a.currentStack.Preview(a.ctx, opts...)
 	if err != nil {
 		a.t.Fatalf("failed to preview update: %s", err)

--- a/pulumitest/refresh.go
+++ b/pulumitest/refresh.go
@@ -13,7 +13,9 @@ func (a *PulumiTest) Refresh(opts ...optrefresh.Option) auto.RefreshResult {
 	if a.currentStack == nil {
 		a.t.Fatal("no current stack")
 	}
-	a.ClearGrpcLog()
+	if !a.options.DisableGrpcLog {
+		a.ClearGrpcLog()
+	}
 	result, err := a.currentStack.Refresh(a.ctx, opts...)
 	if err != nil {
 		a.t.Fatalf("failed to refresh: %s", err)

--- a/pulumitest/refresh.go
+++ b/pulumitest/refresh.go
@@ -13,6 +13,7 @@ func (a *PulumiTest) Refresh(opts ...optrefresh.Option) auto.RefreshResult {
 	if a.currentStack == nil {
 		a.t.Fatal("no current stack")
 	}
+	a.ClearGrpcLog()
 	result, err := a.currentStack.Refresh(a.ctx, opts...)
 	if err != nil {
 		a.t.Fatalf("failed to refresh: %s", err)

--- a/pulumitest/up.go
+++ b/pulumitest/up.go
@@ -13,6 +13,7 @@ func (a *PulumiTest) Up(opts ...optup.Option) auto.UpResult {
 	if a.currentStack == nil {
 		a.t.Fatal("no current stack")
 	}
+	a.ClearGrpcLog()
 	result, err := a.currentStack.Up(a.ctx, opts...)
 	if err != nil {
 		a.t.Fatalf("failed to deploy: %s", err)

--- a/pulumitest/up.go
+++ b/pulumitest/up.go
@@ -13,7 +13,9 @@ func (a *PulumiTest) Up(opts ...optup.Option) auto.UpResult {
 	if a.currentStack == nil {
 		a.t.Fatal("no current stack")
 	}
-	a.ClearGrpcLog()
+	if !a.options.DisableGrpcLog {
+		a.ClearGrpcLog()
+	}
 	result, err := a.currentStack.Up(a.ctx, opts...)
 	if err != nil {
 		a.t.Fatalf("failed to deploy: %s", err)


### PR DESCRIPTION
This PR adds a new utility method `ClearGrpcLog` and uses it to clear the log before a `preview`, `up`, `refresh`, or `destroy` operation. I'm unaware of any use case for retaining the event log across deployments, and forgetting to clear it may otherwise be a common mistake. If a use case emerges, assumedly one could copy the log before running the deployment.