### PR TITLE
Launch providers into workspace directory

### DIFF
--- a/providers/attach.go
+++ b/providers/attach.go
@@ -9,7 +9,7 @@ import (
 
 // StartProviders starts each of the given providers and returns a map of provider names to the ports they are listening on.
 // The context should be cancelled when the test is complete to shut down the providers.
-func StartProviders(ctx context.Context, factories map[ProviderName]ProviderFactory) (map[ProviderName]Port, error) {
+func StartProviders(ctx context.Context, factories map[ProviderName]ProviderFactory, opts ProviderOptions) (map[ProviderName]Port, error) {
 	if len(factories) == 0 {
 		return nil, nil
 	}
@@ -24,7 +24,7 @@ func StartProviders(ctx context.Context, factories map[ProviderName]ProviderFact
 	portMappings := map[ProviderName]Port{}
 	for _, providerName := range providerNames {
 		factory := factories[providerName]
-		port, err := factory(ctx)
+		port, err := factory(ctx, opts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to start provider %s: %v", providerName, err)
 		}

--- a/providers/downloadPluginBinary.go
+++ b/providers/downloadPluginBinary.go
@@ -9,12 +9,12 @@ import (
 )
 
 func DownloadPluginBinaryFactory(name, version string) ProviderFactory {
-	factory := func(ctx context.Context) (Port, error) {
+	factory := func(ctx context.Context, opts ProviderOptions) (Port, error) {
 		binaryPath, err := DownloadPluginBinary(name, version)
 		if err != nil {
 			return 0, err
 		}
-		return startLocalBinary(ctx, binaryPath, name)
+		return startLocalBinary(ctx, binaryPath, name, opts.WorkDir)
 	}
 	return factory
 }

--- a/providers/factory.go
+++ b/providers/factory.go
@@ -8,7 +8,13 @@ type ProviderName string
 // Port is the port that a provider is listening on.
 type Port int
 
+// ProviderOptions is a set of options to be passed to the provider factory.
+type ProviderOptions struct {
+	// WorkDir is the Pulumi workspace directory.
+	WorkDir string
+}
+
 // ProviderFactory is a function that starts a provider and returns the port it is listening on.
 // The function should return an error if the provider fails to start.
 // When the test is complete, the context will be cancelled and the provider should exit.
-type ProviderFactory func(ctx context.Context) (Port, error)
+type ProviderFactory func(ctx context.Context, opts ProviderOptions) (Port, error)

--- a/providers/localBinary.go
+++ b/providers/localBinary.go
@@ -12,13 +12,13 @@ import (
 )
 
 func LocalBinary(name, path string) ProviderFactory {
-	factory := func(ctx context.Context) (Port, error) {
-		return startLocalBinary(ctx, path, name)
+	factory := func(ctx context.Context, opts ProviderOptions) (Port, error) {
+		return startLocalBinary(ctx, path, name, opts.WorkDir)
 	}
 	return factory
 }
 
-func startLocalBinary(ctx context.Context, path string, name string) (Port, error) {
+func startLocalBinary(ctx context.Context, path, name, cwd string) (Port, error) {
 	stat, err := os.Stat(path)
 	if err != nil {
 		return 0, err
@@ -28,6 +28,7 @@ func startLocalBinary(ctx context.Context, path string, name string) (Port, erro
 		path = filepath.Join(path, binaryName)
 	}
 	cmd := exec.CommandContext(ctx, path)
+	cmd.Dir = cwd
 	reader, err := cmd.StdoutPipe()
 	cmd.Stderr = os.Stderr
 	if err != nil {

--- a/providers/localBinary_test.go
+++ b/providers/localBinary_test.go
@@ -12,7 +12,9 @@ func TestLocalBinaryAttach(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	factory := providers.DownloadPluginBinaryFactory("azure-native", "2.25.0")
-	port, err := factory(ctx)
+	port, err := factory(ctx, providers.ProviderOptions{
+		WorkDir: t.TempDir(),
+	})
 	assert.NoError(t, err)
 	assert.NotZero(t, port)
 }

--- a/providers/providerInterceptProxy.go
+++ b/providers/providerInterceptProxy.go
@@ -41,8 +41,8 @@ type ProviderInterceptors struct {
 
 // ProviderInterceptFactory creates a new provider factory that can be used to intercept calls to a downstream provider.
 func ProviderInterceptFactory(ctx context.Context, factory ProviderFactory, interceptors ProviderInterceptors) ProviderFactory {
-	return ResourceProviderFactory(func() (rpc.ResourceProviderServer, error) {
-		port, err := factory(ctx)
+	return ResourceProviderFactory(func(opts ProviderOptions) (rpc.ResourceProviderServer, error) {
+		port, err := factory(ctx, opts)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/providerMock.go
+++ b/providers/providerMock.go
@@ -37,7 +37,7 @@ type ProviderMocks struct {
 
 // ProviderInterceptFactory creates a new provider factory that can be used to intercept calls to a downstream provider.
 func ProviderMockFactory(mocks ProviderMocks) ProviderFactory {
-	return ResourceProviderFactory(func() (rpc.ResourceProviderServer, error) {
+	return ResourceProviderFactory(func(_ ProviderOptions) (rpc.ResourceProviderServer, error) {
 		return NewProviderMock(mocks)
 	})
 }

--- a/providers/resourceProvider.go
+++ b/providers/resourceProvider.go
@@ -9,12 +9,12 @@ import (
 	"google.golang.org/grpc"
 )
 
-type ResourceProviderServerFactory func() (pulumirpc.ResourceProviderServer, error)
+type ResourceProviderServerFactory func(ProviderOptions) (pulumirpc.ResourceProviderServer, error)
 
 // startProvider starts the provider in a goProc and returns the port it's listening on.
 // To shut down the provider, cancel the context.
 func ResourceProviderFactory(makeResourceProviderServer ResourceProviderServerFactory) ProviderFactory {
-	return func(ctx context.Context) (Port, error) {
+	return func(ctx context.Context, opts ProviderOptions) (Port, error) {
 		cancelChannel := make(chan bool)
 		go func() {
 			<-ctx.Done()
@@ -24,7 +24,7 @@ func ResourceProviderFactory(makeResourceProviderServer ResourceProviderServerFa
 		handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 			Cancel: cancelChannel,
 			Init: func(srv *grpc.Server) error {
-				prov, proverr := makeResourceProviderServer()
+				prov, proverr := makeResourceProviderServer(opts)
 				if proverr != nil {
 					return fmt.Errorf("failed to create resource provider server: %v", proverr)
 				}

--- a/pulumitest/newStack.go
+++ b/pulumitest/newStack.go
@@ -55,8 +55,11 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 	providerFactories := options.ProviderFactories()
 	if len(providerFactories) > 0 {
 		pt.t.Log("starting providers")
+		providerOpts := providers.ProviderOptions{
+			WorkDir: pt.source,
+		}
 		providerContext, cancelProviders := context.WithCancel(pt.ctx)
-		providerPorts, err := providers.StartProviders(providerContext, providerFactories)
+		providerPorts, err := providers.StartProviders(providerContext, providerFactories, providerOpts)
 		if err != nil {
 			cancelProviders()
 			pt.t.Fatalf("failed to start providers: %v", err)


### PR DESCRIPTION
Closes #65

Breaking changes:
- `ProviderFactory` signature change to accept `ProviderOpts`
- `ResourceProviderServerFactory` signature change to accept `ProviderOpts`