### PR TITLE
Enable compiling on Windows

### DIFF
--- a/pulumitest/fs_unix.go
+++ b/pulumitest/fs_unix.go
@@ -1,0 +1,27 @@
+//go:build !windows
+// +build !windows
+
+package pulumitest
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+type owner struct {
+	Uid int
+	Gid int
+}
+
+func getFileOwner(fileInfo os.FileInfo) (*owner, error) {
+	stat, ok := fileInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+
+		return nil, fmt.Errorf("failed to get raw syscall.Stat_t data for '%s'", fileInfo.Name())
+	}
+	return &owner{
+		Uid: int(stat.Uid),
+		Gid: int(stat.Gid),
+	}, nil
+}

--- a/pulumitest/fs_unix.go
+++ b/pulumitest/fs_unix.go
@@ -17,7 +17,6 @@ type owner struct {
 func getFileOwner(fileInfo os.FileInfo) (*owner, error) {
 	stat, ok := fileInfo.Sys().(*syscall.Stat_t)
 	if !ok {
-
 		return nil, fmt.Errorf("failed to get raw syscall.Stat_t data for '%s'", fileInfo.Name())
 	}
 	return &owner{

--- a/pulumitest/fs_windows.go
+++ b/pulumitest/fs_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+// +build windows
+
+package pulumitest
+
+import (
+	"os"
+)
+
+type owner struct {
+	Uid int
+	Gid int
+}
+
+func getFileOwner(fileInfo os.FileInfo) (*owner, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/providertest/issues/71

This change enables compiling depending projects, such as Terraform Bridge tests, on Windows.

syscall.Stat_t is not defined on windows.

To reproduce, `GOOS=windows go build ./...`.
