### PR TITLE
Improve the missing response error message

### DIFF
--- a/replay/json_match.go
+++ b/replay/json_match.go
@@ -42,6 +42,9 @@ func AssertJSONMatchesPattern(
 	expectedPattern json.RawMessage,
 	actual json.RawMessage,
 ) {
+	if len(expectedPattern) == 0 {
+		require.Fail(t, "Expected response was missing")
+	}
 	assertJSONMatchesPattern(t, expectedPattern, actual)
 }
 


### PR DESCRIPTION
Previously, the message was `unexpected end of JSON input`, which is confusing when the entire blob passed to Replay is valid JSON.