### PR TITLE
Try to not assume testing.T

### DIFF
--- a/previewProviderUpgrade.go
+++ b/previewProviderUpgrade.go
@@ -1,6 +1,7 @@
 package providertest
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/pulumi/providertest/optproviderupgrade"
@@ -29,7 +30,7 @@ func PreviewProviderUpgrade(t pulumitest.PT, pulumiTest *pulumitest.PulumiTest, 
 			test.Up()
 			grptLog := test.GrpcLog()
 			grpcLogPath := filepath.Join(cacheDir, "grpc.json")
-			t.Logf("writing grpc log to %s", grpcLogPath)
+			t.Log(fmt.Sprintf("writing grpc log to %s", grpcLogPath))
 			grptLog.WriteTo(grpcLogPath)
 		},
 		optrun.WithCache(filepath.Join(cacheDir, "stack.json")),

--- a/previewProviderUpgrade.go
+++ b/previewProviderUpgrade.go
@@ -14,8 +14,8 @@ import (
 // PreviewProviderUpgrade captures the state of a stack from a baseline provider configuration, then previews the stack
 // with the current provider configuration.
 // Uses a default cache directory of "testdata/recorded/TestProviderUpgrade/{programName}/{baselineVersion}".
-func PreviewProviderUpgrade(pulumiTest *pulumitest.PulumiTest, providerName string, baselineVersion string, opts ...optproviderupgrade.PreviewProviderUpgradeOpt) auto.PreviewResult {
-	pulumiTest.PT().Helper()
+func PreviewProviderUpgrade(t pulumitest.PT, pulumiTest *pulumitest.PulumiTest, providerName string, baselineVersion string, opts ...optproviderupgrade.PreviewProviderUpgradeOpt) auto.PreviewResult {
+	t.Helper()
 	previewTest := pulumiTest.CopyToTempDir(opttest.NewStackOptions(optnewstack.DisableAutoDestroy()))
 	options := optproviderupgrade.Defaults()
 	for _, opt := range opts {
@@ -25,11 +25,11 @@ func PreviewProviderUpgrade(pulumiTest *pulumitest.PulumiTest, providerName stri
 	cacheDir := getCacheDir(options, programName, baselineVersion)
 	previewTest.Run(
 		func(test *pulumitest.PulumiTest) {
-			test.PT().Helper()
+			t.Helper()
 			test.Up()
 			grptLog := test.GrpcLog()
 			grpcLogPath := filepath.Join(cacheDir, "grpc.json")
-			test.PT().Logf("writing grpc log to %s", grpcLogPath)
+			t.Logf("writing grpc log to %s", grpcLogPath)
 			grptLog.WriteTo(grpcLogPath)
 		},
 		optrun.WithCache(filepath.Join(cacheDir, "stack.json")),

--- a/previewProviderUpgrade.go
+++ b/previewProviderUpgrade.go
@@ -15,7 +15,7 @@ import (
 // with the current provider configuration.
 // Uses a default cache directory of "testdata/recorded/TestProviderUpgrade/{programName}/{baselineVersion}".
 func PreviewProviderUpgrade(pulumiTest *pulumitest.PulumiTest, providerName string, baselineVersion string, opts ...optproviderupgrade.PreviewProviderUpgradeOpt) auto.PreviewResult {
-	pulumiTest.T().Helper()
+	pulumiTest.PT().Helper()
 	previewTest := pulumiTest.CopyToTempDir(opttest.NewStackOptions(optnewstack.DisableAutoDestroy()))
 	options := optproviderupgrade.Defaults()
 	for _, opt := range opts {
@@ -25,11 +25,11 @@ func PreviewProviderUpgrade(pulumiTest *pulumitest.PulumiTest, providerName stri
 	cacheDir := getCacheDir(options, programName, baselineVersion)
 	previewTest.Run(
 		func(test *pulumitest.PulumiTest) {
-			test.T().Helper()
+			test.PT().Helper()
 			test.Up()
 			grptLog := test.GrpcLog()
 			grpcLogPath := filepath.Join(cacheDir, "grpc.json")
-			test.T().Logf("writing grpc log to %s", grpcLogPath)
+			test.PT().Logf("writing grpc log to %s", grpcLogPath)
 			grptLog.WriteTo(grpcLogPath)
 		},
 		optrun.WithCache(filepath.Join(cacheDir, "stack.json")),

--- a/previewProviderUpgrade_test.go
+++ b/previewProviderUpgrade_test.go
@@ -18,13 +18,13 @@ func TestPreviewUpgradeCached(t *testing.T) {
 	test := pulumitest.NewPulumiTest(t, filepath.Join("pulumitest", "testdata", "yaml_program"),
 		opttest.DownloadProviderVersion("random", "4.15.0"))
 
-	uncachedPreviewResult := providertest.PreviewProviderUpgrade(test, "random", "4.5.0",
+	uncachedPreviewResult := providertest.PreviewProviderUpgrade(t, test, "random", "4.5.0",
 		optproviderupgrade.CacheDir(cacheDir, "{programName}", "{baselineVersion}"),
 		optproviderupgrade.DisableAttach())
 	assertpreview.HasNoReplacements(t, uncachedPreviewResult)
 	assertpreview.HasNoChanges(t, uncachedPreviewResult)
 
-	cachedPreviewResult := providertest.PreviewProviderUpgrade(test, "random", "4.5.0",
+	cachedPreviewResult := providertest.PreviewProviderUpgrade(t, test, "random", "4.5.0",
 		optproviderupgrade.CacheDir(cacheDir, "{programName}", "{baselineVersion}"),
 		optproviderupgrade.DisableAttach())
 	assert.Equal(t, uncachedPreviewResult, cachedPreviewResult, "expected uncached and cached preview to be the same")

--- a/pulumitest/convert.go
+++ b/pulumitest/convert.go
@@ -26,15 +26,15 @@ func (a *PulumiTest) Convert(language string, opts ...opttest.Option) ConvertRes
 	targetDir := filepath.Join(tempDir, fmt.Sprintf("%s-%s", base, language))
 	err := os.Mkdir(targetDir, 0755)
 	if err != nil {
-		a.t.Fatal(err)
+		a.fatal(err)
 	}
 
-	a.t.Logf("converting to %s", language)
+	a.logf("converting to %s", language)
 	cmd := exec.Command("pulumi", "convert", "--language", language, "--generate-only", "--out", targetDir)
 	cmd.Dir = a.source
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		a.t.Fatalf("failed to convert directory: %s\n%s", err, out)
+		a.fatalf("failed to convert directory: %s\n%s", err, out)
 	}
 
 	options := a.options.Copy()

--- a/pulumitest/copy.go
+++ b/pulumitest/copy.go
@@ -21,7 +21,7 @@ func (a *PulumiTest) CopyToTempDir(opts ...opttest.Option) *PulumiTest {
 	destination := filepath.Join(tempDir, sourceBase)
 	err := os.Mkdir(destination, 0755)
 	if err != nil {
-		a.t.Fatal(err)
+		a.fatal(err)
 	}
 
 	return a.CopyTo(destination, opts...)
@@ -34,7 +34,7 @@ func (a *PulumiTest) CopyTo(dir string, opts ...opttest.Option) *PulumiTest {
 
 	err := copyDirectory(a.source, dir)
 	if err != nil {
-		a.t.Fatal(err)
+		a.fatal(err)
 	}
 
 	options := a.options.Copy()

--- a/pulumitest/destroy.go
+++ b/pulumitest/destroy.go
@@ -11,14 +11,14 @@ func (a *PulumiTest) Destroy(opts ...optdestroy.Option) auto.DestroyResult {
 
 	a.t.Log("destroying")
 	if a.currentStack == nil {
-		a.t.Fatal("no current stack")
+		a.fatal("no current stack")
 	}
 	if !a.options.DisableGrpcLog {
 		a.ClearGrpcLog()
 	}
 	result, err := a.currentStack.Destroy(a.ctx, opts...)
 	if err != nil {
-		a.t.Fatalf("failed to destroy: %s", err)
+		a.fatalf("failed to destroy: %s", err)
 	}
 	return result
 }

--- a/pulumitest/exportStack.go
+++ b/pulumitest/exportStack.go
@@ -10,11 +10,11 @@ func (a *PulumiTest) ExportStack() apitype.UntypedDeployment {
 
 	a.t.Log("exporting stack")
 	if a.currentStack == nil {
-		a.t.Fatal("no current stack")
+		a.fatal("no current stack")
 	}
 	out, err := a.currentStack.Workspace().ExportStack(a.Context(), a.currentStack.Name())
 	if err != nil {
-		a.t.Fatalf("failed to export stack: %s", err)
+		a.fatalf("failed to export stack: %s", err)
 	}
 	return out
 }

--- a/pulumitest/grpcLog.go
+++ b/pulumitest/grpcLog.go
@@ -23,7 +23,7 @@ func (pt *PulumiTest) GrpcLog() *grpclog.GrpcLog {
 
 	log, err := grpclog.LoadLog(env["PULUMI_DEBUG_GRPC"])
 	if err != nil {
-		pt.t.Fatalf("failed to load grpc log: %s", err)
+		pt.fatalf("failed to load grpc log: %s", err)
 	}
 	return log
 }
@@ -35,6 +35,6 @@ func (pt *PulumiTest) ClearGrpcLog() {
 		return
 	}
 	if err := os.RemoveAll(env["PULUMI_DEBUG_GRPC"]); err != nil {
-		pt.t.Fatalf("failed to clear gRPC log: %s", err)
+		pt.fatalf("failed to clear gRPC log: %s", err)
 	}
 }

--- a/pulumitest/importStack.go
+++ b/pulumitest/importStack.go
@@ -10,10 +10,10 @@ func (a *PulumiTest) ImportStack(source apitype.UntypedDeployment) {
 
 	a.t.Log("importing stack")
 	if a.currentStack == nil {
-		a.t.Fatal("no current stack")
+		a.fatal("no current stack")
 	}
 	err := a.currentStack.Workspace().ImportStack(a.Context(), a.currentStack.Name(), source)
 	if err != nil {
-		a.t.Fatalf("failed to import stack: %s", err)
+		a.fatalf("failed to import stack: %s", err)
 	}
 }

--- a/pulumitest/install.go
+++ b/pulumitest/install.go
@@ -13,7 +13,7 @@ func (a *PulumiTest) Install() string {
 	cmd.Dir = a.source
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		a.t.Fatalf("failed to install packages and plugins: %s\n%s", err, out)
+		a.fatalf("failed to install packages and plugins: %s\n%s", err, out)
 	}
 	return string(out)
 }

--- a/pulumitest/newStack.go
+++ b/pulumitest/newStack.go
@@ -79,7 +79,7 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 	stackOpts = append(stackOpts, options.ExtraWorkspaceOptions...)
 	stackOpts = append(stackOpts, stackOptions.Opts...)
 
-	pt.T().Logf("creating stack %s", stackName)
+	pt.PT().Logf("creating stack %s", stackName)
 	stack, err := auto.NewStackLocalSource(pt.ctx, stackName, pt.source, stackOpts...)
 
 	providerPluginPaths := options.ProviderPluginPaths()

--- a/pulumitest/newStack.go
+++ b/pulumitest/newStack.go
@@ -59,7 +59,7 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 		providerPorts, err := providers.StartProviders(providerContext, providerFactories, pt)
 		if err != nil {
 			cancelProviders()
-			pt.t.Fatalf("failed to start providers: %v", err)
+			pt.fatalf("failed to start providers: %v", err)
 		} else {
 			pt.t.Cleanup(func() {
 				cancelProviders()
@@ -79,14 +79,14 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 	stackOpts = append(stackOpts, options.ExtraWorkspaceOptions...)
 	stackOpts = append(stackOpts, stackOptions.Opts...)
 
-	pt.t.Logf("creating stack %s", stackName)
+	pt.logf("creating stack %s", stackName)
 	stack, err := auto.NewStackLocalSource(pt.ctx, stackName, pt.source, stackOpts...)
 
 	providerPluginPaths := options.ProviderPluginPaths()
 	if len(providerPluginPaths) > 0 {
 		projectSettings, err := stack.Workspace().ProjectSettings(pt.ctx)
 		if err != nil {
-			pt.t.Fatalf("failed to get project settings: %s", err)
+			pt.fatalf("failed to get project settings: %s", err)
 		}
 		var plugins workspace.Plugins
 		if projectSettings.Plugins != nil {
@@ -103,7 +103,7 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 			relPath := providerPluginPaths[providers.ProviderName(name)]
 			absPath, err := filepath.Abs(relPath)
 			if err != nil {
-				pt.t.Fatalf("failed to get absolute path for %s: %s", relPath, err)
+				pt.fatalf("failed to get absolute path for %s: %s", relPath, err)
 			}
 
 			found := false
@@ -125,7 +125,7 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 		projectSettings.Plugins = &plugins
 		err = stack.Workspace().SaveProjectSettings(pt.ctx, projectSettings)
 		if err != nil {
-			pt.t.Fatalf("failed to save project settings: %s", err)
+			pt.fatalf("failed to save project settings: %s", err)
 		}
 	}
 
@@ -133,10 +133,10 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 		for _, pkg := range options.YarnLinks {
 			cmd := exec.Command("yarn", "link", pkg)
 			cmd.Dir = pt.source
-			pt.t.Logf("linking yarn package: %s", cmd)
+			pt.logf("linking yarn package: %s", cmd)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
-				pt.t.Fatalf("failed to link yarn package %s: %s\n%s", pkg, err, out)
+				pt.fatalf("failed to link yarn package %s: %s\n%s", pkg, err, out)
 			}
 		}
 	}
@@ -151,21 +151,21 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 			relPath := options.GoModReplacements[old]
 			absPath, err := filepath.Abs(relPath)
 			if err != nil {
-				pt.t.Fatalf("failed to get absolute path for %s: %s", relPath, err)
+				pt.fatalf("failed to get absolute path for %s: %s", relPath, err)
 			}
 			replacement := fmt.Sprintf("%s=%s", old, absPath)
 			cmd := exec.Command("go", "mod", "edit", "-replace", replacement)
 			cmd.Dir = pt.source
-			pt.t.Logf("adding go.mod replacement: %s", cmd)
+			pt.logf("adding go.mod replacement: %s", cmd)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
-				pt.t.Fatalf("failed to add go.mod replacement %s: %s\n%s", replacement, err, out)
+				pt.fatalf("failed to add go.mod replacement %s: %s\n%s", replacement, err, out)
 			}
 		}
 	}
 
 	if err != nil {
-		pt.t.Fatalf("failed to create stack: %s", err)
+		pt.fatalf("failed to create stack: %s", err)
 		return nil
 	}
 	if !stackOptions.SkipDestroy {
@@ -174,11 +174,11 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 			pt.t.Log("cleaning up stack")
 			_, err := stack.Destroy(pt.ctx)
 			if err != nil {
-				pt.t.Errorf("failed to destroy stack: %s", err)
+				pt.errorf("failed to destroy stack: %s", err)
 			}
 			err = stack.Workspace().RemoveStack(pt.ctx, stackName, optremove.Force())
 			if err != nil {
-				pt.t.Errorf("failed to remove stack: %s", err)
+				pt.errorf("failed to remove stack: %s", err)
 			}
 		})
 	}

--- a/pulumitest/newStack.go
+++ b/pulumitest/newStack.go
@@ -79,7 +79,7 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 	stackOpts = append(stackOpts, options.ExtraWorkspaceOptions...)
 	stackOpts = append(stackOpts, stackOptions.Opts...)
 
-	pt.PT().Logf("creating stack %s", stackName)
+	pt.t.Logf("creating stack %s", stackName)
 	stack, err := auto.NewStackLocalSource(pt.ctx, stackName, pt.source, stackOpts...)
 
 	providerPluginPaths := options.ProviderPluginPaths()

--- a/pulumitest/preview.go
+++ b/pulumitest/preview.go
@@ -11,14 +11,14 @@ func (a *PulumiTest) Preview(opts ...optpreview.Option) auto.PreviewResult {
 
 	a.t.Log("previewing update")
 	if a.currentStack == nil {
-		a.t.Fatal("no current stack")
+		a.fatal("no current stack")
 	}
 	if !a.options.DisableGrpcLog {
 		a.ClearGrpcLog()
 	}
 	result, err := a.currentStack.Preview(a.ctx, opts...)
 	if err != nil {
-		a.t.Fatalf("failed to preview update: %s", err)
+		a.fatalf("failed to preview update: %s", err)
 	}
 	return result
 }

--- a/pulumitest/pulumiTest.go
+++ b/pulumitest/pulumiTest.go
@@ -2,13 +2,15 @@ package pulumitest
 
 import (
 	"context"
+	"testing"
 
 	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 type PulumiTest struct {
-	t            T
+	t            PT
 	ctx          context.Context
 	source       string
 	options      *opttest.Options
@@ -20,7 +22,7 @@ type PulumiTest struct {
 // 1. Copy the source to a temporary directory.
 // 2. Install dependencies.
 // 3. Create a new stack called "test" with state stored to a local temporary directory and a fixed passphrase for encryption.
-func NewPulumiTest(t T, source string, opts ...opttest.Option) *PulumiTest {
+func NewPulumiTest(t PT, source string, opts ...opttest.Option) *PulumiTest {
 	t.Helper()
 	ctx := testContext(t)
 	options := opttest.DefaultOptions()
@@ -41,7 +43,7 @@ func NewPulumiTest(t T, source string, opts ...opttest.Option) *PulumiTest {
 	return pt
 }
 
-func testContext(t T) context.Context {
+func testContext(t PT) context.Context {
 	t.Helper()
 	var ctx context.Context
 	var cancel context.CancelFunc
@@ -70,9 +72,17 @@ func (a *PulumiTest) Source() string {
 	return a.source
 }
 
-// T returns the current testing.T instance.
-func (a *PulumiTest) T() T {
+// PT returns the current PT instance.
+func (a *PulumiTest) PT() PT {
 	return a.t
+}
+
+// Please use [PulumiTest.PT] instead.
+// Deprecated.
+func (a *PulumiTest) T() *testing.T {
+	r, ok := a.PT().(*testing.T)
+	contract.Assertf(ok, "Testing with something other than *testing.T; Please use PulumiTest.PT()")
+	return r
 }
 
 // Context returns the current context.Context instance used for automation API calls.

--- a/pulumitest/pulumiTest.go
+++ b/pulumitest/pulumiTest.go
@@ -2,14 +2,13 @@ package pulumitest
 
 import (
 	"context"
-	"testing"
 
 	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 )
 
 type PulumiTest struct {
-	t            *testing.T
+	t            T
 	ctx          context.Context
 	source       string
 	options      *opttest.Options
@@ -21,7 +20,7 @@ type PulumiTest struct {
 // 1. Copy the source to a temporary directory.
 // 2. Install dependencies.
 // 3. Create a new stack called "test" with state stored to a local temporary directory and a fixed passphrase for encryption.
-func NewPulumiTest(t *testing.T, source string, opts ...opttest.Option) *PulumiTest {
+func NewPulumiTest(t T, source string, opts ...opttest.Option) *PulumiTest {
 	t.Helper()
 	ctx := testContext(t)
 	options := opttest.DefaultOptions()
@@ -42,7 +41,7 @@ func NewPulumiTest(t *testing.T, source string, opts ...opttest.Option) *PulumiT
 	return pt
 }
 
-func testContext(t *testing.T) context.Context {
+func testContext(t T) context.Context {
 	t.Helper()
 	var ctx context.Context
 	var cancel context.CancelFunc
@@ -72,7 +71,7 @@ func (a *PulumiTest) Source() string {
 }
 
 // T returns the current testing.T instance.
-func (a *PulumiTest) T() *testing.T {
+func (a *PulumiTest) T() T {
 	return a.t
 }
 

--- a/pulumitest/pulumiTest.go
+++ b/pulumitest/pulumiTest.go
@@ -2,11 +2,9 @@ package pulumitest
 
 import (
 	"context"
-	"testing"
 
 	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 type PulumiTest struct {
@@ -70,19 +68,6 @@ func pulumiTestInit(pt *PulumiTest, options *opttest.Options) {
 // Source returns the current source directory.
 func (a *PulumiTest) Source() string {
 	return a.source
-}
-
-// PT returns the current PT instance.
-func (a *PulumiTest) PT() PT {
-	return a.t
-}
-
-// Please use [PulumiTest.PT] instead.
-// Deprecated.
-func (a *PulumiTest) T() *testing.T {
-	r, ok := a.PT().(*testing.T)
-	contract.Assertf(ok, "Testing with something other than *testing.T; Please use PulumiTest.PT()")
-	return r
 }
 
 // Context returns the current context.Context instance used for automation API calls.

--- a/pulumitest/pulumiTest.go
+++ b/pulumitest/pulumiTest.go
@@ -2,6 +2,7 @@ package pulumitest
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
@@ -78,4 +79,32 @@ func (a *PulumiTest) Context() context.Context {
 // CurrentStack returns the last stack that was created or nil if no stack has been created yet.
 func (a *PulumiTest) CurrentStack() *auto.Stack {
 	return a.currentStack
+}
+
+func (a *PulumiTest) logf(format string, args ...any) {
+	a.t.Log(fmt.Sprintf(format, args...))
+}
+
+func (a *PulumiTest) log(args ...any) {
+	a.t.Log(args...)
+}
+
+func (a *PulumiTest) errorf(format string, args ...any) {
+	a.t.Log(fmt.Sprintf(format, args...))
+	a.t.Fail()
+}
+
+func (a *PulumiTest) error(args ...any) {
+	a.t.Log(args...)
+	a.t.Fail()
+}
+
+func (a *PulumiTest) fatalf(format string, args ...any) {
+	a.t.Log(fmt.Sprintf(format, args...))
+	a.t.FailNow()
+}
+
+func (a *PulumiTest) fatal(args ...any) {
+	a.t.Log(args...)
+	a.t.FailNow()
 }

--- a/pulumitest/refresh.go
+++ b/pulumitest/refresh.go
@@ -11,14 +11,14 @@ func (a *PulumiTest) Refresh(opts ...optrefresh.Option) auto.RefreshResult {
 
 	a.t.Log("refreshing")
 	if a.currentStack == nil {
-		a.t.Fatal("no current stack")
+		a.fatal("no current stack")
 	}
 	if !a.options.DisableGrpcLog {
 		a.ClearGrpcLog()
 	}
 	result, err := a.currentStack.Refresh(a.ctx, opts...)
 	if err != nil {
-		a.t.Fatalf("failed to refresh: %s", err)
+		a.fatalf("failed to refresh: %s", err)
 	}
 	return result
 }

--- a/pulumitest/run.go
+++ b/pulumitest/run.go
@@ -16,7 +16,7 @@ import (
 // WithCache can be used to skip executing the run and return the cached stack state if available, or to cache the stack state after executing the run.
 // Options will be inherited from the original test, but can be added to with `optrun.WithOpts` or reset with `opttest.Defaults()`.
 func (pulumiTest *PulumiTest) Run(execute func(test *PulumiTest), opts ...optrun.Option) *PulumiTest {
-	pulumiTest.T().Helper()
+	pulumiTest.PT().Helper()
 
 	options := optrun.DefaultOptions()
 	for _, o := range opts {
@@ -28,12 +28,12 @@ func (pulumiTest *PulumiTest) Run(execute func(test *PulumiTest), opts ...optrun
 	if options.EnableCache {
 		stackExport, err = tryReadStackExport(options.CachePath)
 		if err != nil {
-			pulumiTest.T().Fatalf("failed to read stack export: %v", err)
+			pulumiTest.PT().Fatalf("failed to read stack export: %v", err)
 		}
 		if stackExport != nil {
-			pulumiTest.T().Logf("run cache found at %s", options.CachePath)
+			pulumiTest.PT().Logf("run cache found at %s", options.CachePath)
 		} else {
-			pulumiTest.T().Logf("no run cache found at %s", options.CachePath)
+			pulumiTest.PT().Logf("no run cache found at %s", options.CachePath)
 		}
 	}
 
@@ -42,10 +42,10 @@ func (pulumiTest *PulumiTest) Run(execute func(test *PulumiTest), opts ...optrun
 		execute(isolatedTest)
 		exportedStack := isolatedTest.ExportStack()
 		if options.EnableCache {
-			isolatedTest.T().Logf("writing stack state to %s", options.CachePath)
+			isolatedTest.PT().Logf("writing stack state to %s", options.CachePath)
 			err = writeStackExport(options.CachePath, &exportedStack, false /* overwrite */)
 			if err != nil {
-				isolatedTest.T().Fatalf("failed to write snapshot to %s: %v", options.CachePath, err)
+				isolatedTest.PT().Fatalf("failed to write snapshot to %s: %v", options.CachePath, err)
 			}
 		}
 		stackExport = &exportedStack
@@ -55,13 +55,13 @@ func (pulumiTest *PulumiTest) Run(execute func(test *PulumiTest), opts ...optrun
 	stackName := pulumiTest.CurrentStack().Name()
 	fixedStack, err := fixupStackName(stackExport, stackName)
 	if err != nil {
-		pulumiTest.T().Fatalf("failed to fixup stack name: %v", err)
+		pulumiTest.PT().Fatalf("failed to fixup stack name: %v", err)
 	}
 	if fixedStack != stackExport {
-		pulumiTest.T().Logf("updating snapshot with fixed stack name: %s", stackName)
+		pulumiTest.PT().Logf("updating snapshot with fixed stack name: %s", stackName)
 		err = writeStackExport(options.CachePath, fixedStack, true /* overwrite */)
 		if err != nil {
-			pulumiTest.T().Fatalf("failed to write snapshot to %s: %v", options.CachePath, err)
+			pulumiTest.PT().Fatalf("failed to write snapshot to %s: %v", options.CachePath, err)
 		}
 		stackExport = fixedStack
 	}

--- a/pulumitest/run.go
+++ b/pulumitest/run.go
@@ -16,7 +16,7 @@ import (
 // WithCache can be used to skip executing the run and return the cached stack state if available, or to cache the stack state after executing the run.
 // Options will be inherited from the original test, but can be added to with `optrun.WithOpts` or reset with `opttest.Defaults()`.
 func (pulumiTest *PulumiTest) Run(execute func(test *PulumiTest), opts ...optrun.Option) *PulumiTest {
-	pulumiTest.PT().Helper()
+	pulumiTest.t.Helper()
 
 	options := optrun.DefaultOptions()
 	for _, o := range opts {
@@ -28,12 +28,12 @@ func (pulumiTest *PulumiTest) Run(execute func(test *PulumiTest), opts ...optrun
 	if options.EnableCache {
 		stackExport, err = tryReadStackExport(options.CachePath)
 		if err != nil {
-			pulumiTest.PT().Fatalf("failed to read stack export: %v", err)
+			pulumiTest.t.Fatalf("failed to read stack export: %v", err)
 		}
 		if stackExport != nil {
-			pulumiTest.PT().Logf("run cache found at %s", options.CachePath)
+			pulumiTest.t.Logf("run cache found at %s", options.CachePath)
 		} else {
-			pulumiTest.PT().Logf("no run cache found at %s", options.CachePath)
+			pulumiTest.t.Logf("no run cache found at %s", options.CachePath)
 		}
 	}
 
@@ -42,10 +42,10 @@ func (pulumiTest *PulumiTest) Run(execute func(test *PulumiTest), opts ...optrun
 		execute(isolatedTest)
 		exportedStack := isolatedTest.ExportStack()
 		if options.EnableCache {
-			isolatedTest.PT().Logf("writing stack state to %s", options.CachePath)
+			isolatedTest.t.Logf("writing stack state to %s", options.CachePath)
 			err = writeStackExport(options.CachePath, &exportedStack, false /* overwrite */)
 			if err != nil {
-				isolatedTest.PT().Fatalf("failed to write snapshot to %s: %v", options.CachePath, err)
+				isolatedTest.t.Fatalf("failed to write snapshot to %s: %v", options.CachePath, err)
 			}
 		}
 		stackExport = &exportedStack
@@ -55,13 +55,13 @@ func (pulumiTest *PulumiTest) Run(execute func(test *PulumiTest), opts ...optrun
 	stackName := pulumiTest.CurrentStack().Name()
 	fixedStack, err := fixupStackName(stackExport, stackName)
 	if err != nil {
-		pulumiTest.PT().Fatalf("failed to fixup stack name: %v", err)
+		pulumiTest.t.Fatalf("failed to fixup stack name: %v", err)
 	}
 	if fixedStack != stackExport {
-		pulumiTest.PT().Logf("updating snapshot with fixed stack name: %s", stackName)
+		pulumiTest.t.Logf("updating snapshot with fixed stack name: %s", stackName)
 		err = writeStackExport(options.CachePath, fixedStack, true /* overwrite */)
 		if err != nil {
-			pulumiTest.PT().Fatalf("failed to write snapshot to %s: %v", options.CachePath, err)
+			pulumiTest.t.Fatalf("failed to write snapshot to %s: %v", options.CachePath, err)
 		}
 		stackExport = fixedStack
 	}

--- a/pulumitest/run.go
+++ b/pulumitest/run.go
@@ -28,12 +28,12 @@ func (pulumiTest *PulumiTest) Run(execute func(test *PulumiTest), opts ...optrun
 	if options.EnableCache {
 		stackExport, err = tryReadStackExport(options.CachePath)
 		if err != nil {
-			pulumiTest.t.Fatalf("failed to read stack export: %v", err)
+			pulumiTest.fatalf("failed to read stack export: %v", err)
 		}
 		if stackExport != nil {
-			pulumiTest.t.Logf("run cache found at %s", options.CachePath)
+			pulumiTest.logf("run cache found at %s", options.CachePath)
 		} else {
-			pulumiTest.t.Logf("no run cache found at %s", options.CachePath)
+			pulumiTest.logf("no run cache found at %s", options.CachePath)
 		}
 	}
 
@@ -42,10 +42,10 @@ func (pulumiTest *PulumiTest) Run(execute func(test *PulumiTest), opts ...optrun
 		execute(isolatedTest)
 		exportedStack := isolatedTest.ExportStack()
 		if options.EnableCache {
-			isolatedTest.t.Logf("writing stack state to %s", options.CachePath)
+			isolatedTest.logf("writing stack state to %s", options.CachePath)
 			err = writeStackExport(options.CachePath, &exportedStack, false /* overwrite */)
 			if err != nil {
-				isolatedTest.t.Fatalf("failed to write snapshot to %s: %v", options.CachePath, err)
+				isolatedTest.fatalf("failed to write snapshot to %s: %v", options.CachePath, err)
 			}
 		}
 		stackExport = &exportedStack
@@ -55,13 +55,13 @@ func (pulumiTest *PulumiTest) Run(execute func(test *PulumiTest), opts ...optrun
 	stackName := pulumiTest.CurrentStack().Name()
 	fixedStack, err := fixupStackName(stackExport, stackName)
 	if err != nil {
-		pulumiTest.t.Fatalf("failed to fixup stack name: %v", err)
+		pulumiTest.fatalf("failed to fixup stack name: %v", err)
 	}
 	if fixedStack != stackExport {
-		pulumiTest.t.Logf("updating snapshot with fixed stack name: %s", stackName)
+		pulumiTest.logf("updating snapshot with fixed stack name: %s", stackName)
 		err = writeStackExport(options.CachePath, fixedStack, true /* overwrite */)
 		if err != nil {
-			pulumiTest.t.Fatalf("failed to write snapshot to %s: %v", options.CachePath, err)
+			pulumiTest.fatalf("failed to write snapshot to %s: %v", options.CachePath, err)
 		}
 		stackExport = fixedStack
 	}

--- a/pulumitest/setConfig.go
+++ b/pulumitest/setConfig.go
@@ -6,10 +6,10 @@ func (a *PulumiTest) SetConfig(key, value string) {
 	a.t.Helper()
 
 	if a.currentStack == nil {
-		a.t.Fatal("no current stack")
+		a.fatal("no current stack")
 	}
 	err := a.currentStack.SetConfig(a.ctx, key, auto.ConfigValue{Value: value})
 	if err != nil {
-		a.t.Fatalf("failed to set config: %s", err)
+		a.fatalf("failed to set config: %s", err)
 	}
 }

--- a/pulumitest/testingT.go
+++ b/pulumitest/testingT.go
@@ -7,11 +7,9 @@ import (
 // A subset of *testing.T functionality used by pulumitest.
 type PT interface {
 	TempDir() string
-	Fatal(...any)
-	Fatalf(string, ...any)
 	Log(...any)
-	Logf(string, ...any)
-	Errorf(string, ...any)
+	Fail()
+	FailNow()
 	Cleanup(func())
 	Helper()
 	Deadline() (time.Time, bool)

--- a/pulumitest/testingT.go
+++ b/pulumitest/testingT.go
@@ -4,7 +4,8 @@ import (
 	"time"
 )
 
-type T interface {
+// A subset of *testing.T functionality used by pulumitest.
+type PT interface {
 	TempDir() string
 	Fatal(...any)
 	Fatalf(string, ...any)

--- a/pulumitest/testingT.go
+++ b/pulumitest/testingT.go
@@ -1,0 +1,17 @@
+package pulumitest
+
+import (
+	"time"
+)
+
+type T interface {
+	TempDir() string
+	Fatal(...any)
+	Fatalf(string, ...any)
+	Log(...any)
+	Logf(string, ...any)
+	Errorf(string, ...any)
+	Cleanup(func())
+	Helper()
+	Deadline() (time.Time, bool)
+}

--- a/pulumitest/up.go
+++ b/pulumitest/up.go
@@ -11,14 +11,14 @@ func (a *PulumiTest) Up(opts ...optup.Option) auto.UpResult {
 
 	a.t.Log("deploying")
 	if a.currentStack == nil {
-		a.t.Fatal("no current stack")
+		a.fatal("no current stack")
 	}
 	if !a.options.DisableGrpcLog {
 		a.ClearGrpcLog()
 	}
 	result, err := a.currentStack.Up(a.ctx, opts...)
 	if err != nil {
-		a.t.Fatalf("failed to deploy: %s", err)
+		a.fatalf("failed to deploy: %s", err)
 	}
 	return result
 }

--- a/pulumitest/updateSource.go
+++ b/pulumitest/updateSource.go
@@ -7,6 +7,6 @@ func (a *PulumiTest) UpdateSource(pathElems ...string) {
 	a.t.Helper()
 
 	path := filepath.Join(pathElems...)
-	a.t.Logf("updating source from %s", path)
+	a.logf("updating source from %s", path)
 	copyDirectory(path, a.source)
 }


### PR DESCRIPTION
Generalizing from concrete testing.T allows using in other test contexts, such as rapid testing. 

Breaking: remove `PulumiTest.T()` accessor:

```
func (a *PulumiTest) T() T
```