### PR TITLE
Retain temporary folders for inspection when tests failed

### DIFF
--- a/pulumitest/ciutil.go
+++ b/pulumitest/ciutil.go
@@ -1,0 +1,10 @@
+package pulumitest
+
+import (
+	"os"
+)
+
+var runningInCI = (func() func() bool {
+	_, ok := os.LookupEnv("CI")
+	return func() bool { return ok }
+})()

--- a/pulumitest/copy.go
+++ b/pulumitest/copy.go
@@ -14,7 +14,7 @@ import (
 // This is used to avoid temporary files being written to the source directory.
 func (a *PulumiTest) CopyToTempDir(opts ...opttest.Option) *PulumiTest {
 	a.t.Helper()
-	tempDir := a.t.TempDir()
+	tempDir := tempDirWithoutCleanupOnFailedTest(a.t, "programDir")
 
 	// Maintain the directory name in the temp dir as this might be used for stack naming.
 	sourceBase := filepath.Base(a.source)

--- a/pulumitest/newStack.go
+++ b/pulumitest/newStack.go
@@ -174,7 +174,7 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 		pt.t.Cleanup(func() {
 			pt.t.Helper()
 
-			if ptFailed(pt.t) {
+			if ptFailed(pt.t) && !runningInCI() {
 				pt.t.Log(fmt.Sprintf("refusing to destroy stack at %q to help debug the failing test",
 					stack.Workspace().WorkDir()))
 				return

--- a/pulumitest/newStack.go
+++ b/pulumitest/newStack.go
@@ -49,7 +49,7 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 	}
 
 	if !options.DisableGrpcLog {
-		grpcLogDir := tempDirWithoutCleanupOnFailedTest(pt.t, pt.t.TempDir())
+		grpcLogDir := tempDirWithoutCleanupOnFailedTest(pt.t, "grpcLogDir")
 		pt.t.Log("PULUMI_DEBUG_GRPC=" + filepath.Join(grpcLogDir, "grpc.json"))
 		env["PULUMI_DEBUG_GRPC"] = filepath.Join(grpcLogDir, "grpc.json")
 	}

--- a/pulumitest/tempdir.go
+++ b/pulumitest/tempdir.go
@@ -1,0 +1,95 @@
+package pulumitest
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"unicode"
+	"unicode/utf8"
+)
+
+func tempDirWithoutCleanupOnFailedTest(t PT, desc string) string {
+	t.TempDir()
+	c := getOrCreateTempDirState(t)
+
+	// Use a single parent directory for all the temporary directories
+	// created by a test, each numbered sequentially.
+	c.tempDirMu.Lock()
+	var nonExistent bool
+	if c.tempDir == "" { // Usually the case with js/wasm
+		nonExistent = true
+	} else {
+		_, err := os.Stat(c.tempDir)
+		nonExistent = os.IsNotExist(err)
+		if err != nil && !nonExistent {
+			ptFatalF(t, "TempDir: %v", err)
+		}
+	}
+
+	if nonExistent {
+		t.Helper()
+
+		// Drop unusual characters (such as path separators or
+		// characters interacting with globs) from the directory name to
+		// avoid surprising os.MkdirTemp behavior.
+		mapper := func(r rune) rune {
+			if r < utf8.RuneSelf {
+				const allowed = "!#$%&()+,-.=@^_{}~ "
+				if '0' <= r && r <= '9' ||
+					'a' <= r && r <= 'z' ||
+					'A' <= r && r <= 'Z' {
+					return r
+				}
+				if strings.ContainsRune(allowed, r) {
+					return r
+				}
+			} else if unicode.IsLetter(r) || unicode.IsNumber(r) {
+				return r
+			}
+			return -1
+		}
+		pattern := strings.Map(mapper, t.Name())
+		c.tempDir, c.tempDirErr = os.MkdirTemp("", pattern)
+		if c.tempDirErr == nil {
+			t.Cleanup(func() {
+				if ptFailed(t) {
+					ptErrorF(t, "TempDir leaving %s to help debugging: %q", desc, c.tempDir)
+				} else if err := os.RemoveAll(c.tempDir); err != nil {
+					ptErrorF(t, "TempDir RemoveAll cleanup: %v", err)
+				}
+			})
+		}
+	}
+
+	if c.tempDirErr == nil {
+		c.tempDirSeq++
+	}
+	seq := c.tempDirSeq
+	c.tempDirMu.Unlock()
+
+	if c.tempDirErr != nil {
+		ptFatalF(t, "TempDir: %v", c.tempDirErr)
+	}
+
+	dir := fmt.Sprintf("%s%c%03d", c.tempDir, os.PathSeparator, seq)
+	if err := os.Mkdir(dir, 0777); err != nil {
+		ptFatalF(t, "TempDir: %v", err)
+	}
+	return dir
+}
+
+type tempDirState struct {
+	tempDir    string
+	tempDirMu  sync.Mutex
+	tempDirSeq int
+	tempDirErr error
+}
+
+var tempDirStates sync.Map
+
+func getOrCreateTempDirState(pointer any) *tempDirState {
+	fresh := &tempDirState{}
+	st, _ := tempDirStates.LoadOrStore(pointer, fresh)
+	return st.(*tempDirState)
+}

--- a/pulumitest/tempdir.go
+++ b/pulumitest/tempdir.go
@@ -53,7 +53,7 @@ func tempDirWithoutCleanupOnFailedTest(t PT, desc string) string {
 		c.tempDir, c.tempDirErr = os.MkdirTemp("", pattern)
 		if c.tempDirErr == nil {
 			t.Cleanup(func() {
-				if ptFailed(t) {
+				if ptFailed(t) && !runningInCI() {
 					ptErrorF(t, "TempDir leaving %s to help debugging: %q", desc, c.tempDir)
 				} else if err := os.RemoveAll(c.tempDir); err != nil {
 					ptErrorF(t, "TempDir RemoveAll cleanup: %v", err)

--- a/pulumitest/tempdir.go
+++ b/pulumitest/tempdir.go
@@ -10,7 +10,6 @@ import (
 )
 
 func tempDirWithoutCleanupOnFailedTest(t PT, desc string) string {
-	t.TempDir()
 	c := getOrCreateTempDirState(t)
 
 	// Use a single parent directory for all the temporary directories

--- a/pulumitest/testingT.go
+++ b/pulumitest/testingT.go
@@ -1,11 +1,13 @@
 package pulumitest
 
 import (
+	"fmt"
 	"time"
 )
 
 // A subset of *testing.T functionality used by pulumitest.
 type PT interface {
+	Name() string
 	TempDir() string
 	Log(...any)
 	Fail()
@@ -13,4 +15,23 @@ type PT interface {
 	Cleanup(func())
 	Helper()
 	Deadline() (time.Time, bool)
+}
+
+func ptErrorF(t PT, format string, args ...any) {
+	t.Log(fmt.Sprintf(format, args...))
+	t.Fail()
+}
+
+func ptFatalF(t PT, format string, args ...any) {
+	t.Log(fmt.Sprintf(format, args...))
+	t.FailNow()
+}
+
+func ptFailed(t PT) bool {
+	if tF, tFailedSupported := t.(interface {
+		Failed() bool
+	}); tFailedSupported && tF.Failed() {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
This came out of the friction of debugging a failed upgrade test. ProgramTest had a nice feature that left a folder in TMP with the current state right at the point of failure that can be further inspected in the CLI, printing the path to the folder when that happens.

This change moves us closer to the desired experience by substituting t.TempDir() with an inlined version of TempDir that does not delete it on failure; and similarly it stops destroying stacks for failed tests.

There is some further ergonomics to work out such as emitting an .envrc file so that all the env vars get picked up in the dir and the user does not need to chase down the file backend URL, passphrase and so on.