### PR TITLE
Fix baseline version of upgrade tests

### DIFF
--- a/pulumitest/newStack.go
+++ b/pulumitest/newStack.go
@@ -109,9 +109,9 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 			}
 
 			found := false
-			for _, provider := range providerPlugins {
-				if provider.Name == name {
-					provider.Path = absPath
+			for idx := range providerPlugins {
+				if providerPlugins[idx].Name == name {
+					providerPlugins[idx].Path = absPath
 					found = true
 					break
 				}


### PR DESCRIPTION
Previously the path to the baseline version of upgrade tests wasn't correctly set and this caused the upgrade tests to use the current development version instead of the configured baseline version.
This change fixes that.
