### PR TITLE
feat: allow passing additional args to import command

### DIFF
--- a/pulumitest/import.go
+++ b/pulumitest/import.go
@@ -1,7 +1,7 @@
 package pulumitest
 
 func (a *PulumiTest) Import(
-	resourceType, resourceName, resourceID string, providerUrn string,
+	resourceType, resourceName, resourceID string, providerUrn string, args ...string,
 ) cmdOutput {
 	a.t.Helper()
 	arguments := []string{
@@ -10,6 +10,7 @@ func (a *PulumiTest) Import(
 	if providerUrn != "" {
 		arguments = append(arguments, "--provider="+providerUrn)
 	}
+	arguments = append(arguments, args...)
 	ret := a.execCmd(arguments...)
 	if ret.ReturnCode != 0 {
 		a.log(ret.Stdout)

--- a/pulumitest/import_test.go
+++ b/pulumitest/import_test.go
@@ -2,9 +2,12 @@ package pulumitest_test
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/pulumi/providertest/pulumitest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,6 +19,47 @@ func TestImport(t *testing.T) {
 
 	// Assert on the generated YAML containing a resource definition
 	require.Contains(t, res.Stdout, "type: random:RandomString")
+
+	// Assert on the stack containing the resource state
+	stack := test.ExportStack()
+	data, err := stack.Deployment.MarshalJSON()
+	require.NoError(t, err)
+	var stateMap map[string]interface{}
+	err = json.Unmarshal(data, &stateMap)
+	require.NoError(t, err)
+
+	resourcesJSON := stateMap["resources"].([]interface{})
+
+	for _, res := range resourcesJSON {
+		// get the id
+
+		id := res.(map[string]interface{})["id"]
+		if id == "importedString" {
+			return
+		}
+	}
+
+	t.Fatalf("resource not found in state")
+}
+
+func TestImportWithArgs(t *testing.T) {
+	t.Parallel()
+	test := pulumitest.NewPulumiTest(t, "testdata/yaml_empty")
+
+	outFile := filepath.Join(test.CurrentStack().Workspace().WorkDir(), "out.yaml")
+	res := test.Import("random:index/randomString:RandomString", "str", "importedString", "", "--out", outFile)
+
+	assert.Equal(t, []string{
+		"import",
+		"random:index/randomString:RandomString",
+		"str", "importedString", "--yes", "--protect=false",
+		"-s", test.CurrentStack().Name(), "--out", outFile,
+	}, res.Args)
+
+	// Assert on the generated YAML containing a resource definition
+	contents, err := os.ReadFile(outFile)
+	assert.NoError(t, err)
+	assert.Contains(t, string(contents), "type: random:RandomString")
 
 	// Assert on the stack containing the resource state
 	stack := test.ExportStack()


### PR DESCRIPTION
This PR adds the ability to pass additional arguments to the `import`
command.