### PR TITLE
Upgrade tests with known source edits

### DIFF
--- a/optproviderupgrade/optproviderupgrade.go
+++ b/optproviderupgrade/optproviderupgrade.go
@@ -38,10 +38,17 @@ func CacheDir(elem ...string) PreviewProviderUpgradeOpt {
 	})
 }
 
+func NewSourcePath(path string) PreviewProviderUpgradeOpt {
+	return optionFunc(func(o *PreviewProviderUpgradeOptions) {
+		o.NewSourcePath = path
+	})
+}
+
 type PreviewProviderUpgradeOptions struct {
 	CacheDirTemplate []string
 	DisableAttach    bool
 	BaselineOpts     []opttest.Option
+	NewSourcePath    string
 }
 
 type PreviewProviderUpgradeOpt interface {

--- a/previewProviderUpgrade.go
+++ b/previewProviderUpgrade.go
@@ -39,6 +39,10 @@ func PreviewProviderUpgrade(t pulumitest.PT, pulumiTest *pulumitest.PulumiTest, 
 			baselineProviderOpt(options, providerName, baselineVersion)),
 		optrun.WithOpts(options.BaselineOpts...),
 	)
+
+	if options.NewSourcePath != "" {
+		previewTest.UpdateSource(options.NewSourcePath)
+	}
 	return previewTest.Preview()
 }
 

--- a/previewProviderUpgrade_test.go
+++ b/previewProviderUpgrade_test.go
@@ -29,3 +29,18 @@ func TestPreviewUpgradeCached(t *testing.T) {
 		optproviderupgrade.DisableAttach())
 	assert.Equal(t, uncachedPreviewResult, cachedPreviewResult, "expected uncached and cached preview to be the same")
 }
+
+func TestPreviewUpgradeWithKnownSourceEdit(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	test := pulumitest.NewPulumiTest(t, filepath.Join("pulumitest", "testdata", "yaml_program"),
+		opttest.DownloadProviderVersion("random", "4.15.0"))
+
+	previewResult := providertest.PreviewProviderUpgrade(t, test, "random", "4.5.0",
+		optproviderupgrade.CacheDir(cacheDir, "{programName}", "{baselineVersion}"),
+		optproviderupgrade.DisableAttach(),
+		optproviderupgrade.NewSourcePath(filepath.Join("pulumitest", "testdata", "yaml_program_updated")),
+	)
+
+	assert.Contains(t, previewResult.StdOut, "random:index:RandomPassword password create")
+}


### PR DESCRIPTION
This adds a `NewSourcePath` option to the `PreviewProviderUpgrade` function in order to allow running upgrade tests where the new program needs some source edits.

fixes https://github.com/pulumi/providertest/issues/64