### PR TITLE
Don't ignore UpdateSource errors

### DIFF
--- a/pulumitest/updateSource.go
+++ b/pulumitest/updateSource.go
@@ -8,5 +8,9 @@ func (a *PulumiTest) UpdateSource(pathElems ...string) {
 
 	path := filepath.Join(pathElems...)
 	a.logf("updating source from %s", path)
-	copyDirectory(path, a.source)
+	err := copyDirectory(path, a.source)
+	if err != nil {
+		a.t.Log(err)
+		a.t.FailNow()
+	}
 }

--- a/pulumitest/updateSource_test.go
+++ b/pulumitest/updateSource_test.go
@@ -17,4 +17,32 @@ func TestUpdateSource(t *testing.T) {
 
 	changes := *updated.Summary.ResourceChanges
 	assert.Equal(t, 1, changes["create"])
+
+}
+
+func TestUpdateSourceError(t *testing.T) {
+	t.Parallel()
+
+	tt := &mockT{T: t}
+	test := pulumitest.NewPulumiTest(tt, "testdata/yaml_program")
+	test.UpdateSource("this-should-fail")
+
+	assert.True(t, tt.Failed())
+}
+
+type mockT struct {
+	*testing.T
+	failed bool
+}
+
+func (m *mockT) Fail() {
+	m.failed = true
+}
+
+func (m *mockT) FailNow() {
+	m.failed = true
+}
+
+func (m *mockT) Failed() bool {
+	return m.failed
 }


### PR DESCRIPTION
`copyDirectory` can currently fail silently, for example if the provided directory doesn't exist.

We should fail in this situation instead of allowing the test to continue with the prior source.