### PR TITLE
Rename Source to WorkingDir

### DIFF
--- a/pulumitest/convert.go
+++ b/pulumitest/convert.go
@@ -22,7 +22,7 @@ func (a *PulumiTest) Convert(language string, opts ...opttest.Option) ConvertRes
 	a.t.Helper()
 
 	tempDir := a.t.TempDir()
-	base := filepath.Base(a.source)
+	base := filepath.Base(a.workingDir)
 	targetDir := filepath.Join(tempDir, fmt.Sprintf("%s-%s", base, language))
 	err := os.Mkdir(targetDir, 0755)
 	if err != nil {
@@ -31,7 +31,7 @@ func (a *PulumiTest) Convert(language string, opts ...opttest.Option) ConvertRes
 
 	a.logf("converting to %s", language)
 	cmd := exec.Command("pulumi", "convert", "--language", language, "--generate-only", "--out", targetDir)
-	cmd.Dir = a.source
+	cmd.Dir = a.workingDir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		a.fatalf("failed to convert directory: %s\n%s", err, out)
@@ -43,10 +43,10 @@ func (a *PulumiTest) Convert(language string, opts ...opttest.Option) ConvertRes
 	}
 
 	convertedTest := &PulumiTest{
-		t:       a.t,
-		ctx:     a.ctx,
-		source:  targetDir,
-		options: options,
+		t:          a.t,
+		ctx:        a.ctx,
+		workingDir: targetDir,
+		options:    options,
 	}
 	pulumiTestInit(convertedTest, options)
 	return ConvertResult{

--- a/pulumitest/copy.go
+++ b/pulumitest/copy.go
@@ -17,7 +17,7 @@ func (a *PulumiTest) CopyToTempDir(opts ...opttest.Option) *PulumiTest {
 	tempDir := tempDirWithoutCleanupOnFailedTest(a.t, "programDir")
 
 	// Maintain the directory name in the temp dir as this might be used for stack naming.
-	sourceBase := filepath.Base(a.source)
+	sourceBase := filepath.Base(a.workingDir)
 	destination := filepath.Join(tempDir, sourceBase)
 	err := os.Mkdir(destination, 0755)
 	if err != nil {
@@ -32,7 +32,7 @@ func (a *PulumiTest) CopyToTempDir(opts ...opttest.Option) *PulumiTest {
 func (a *PulumiTest) CopyTo(dir string, opts ...opttest.Option) *PulumiTest {
 	a.t.Helper()
 
-	err := copyDirectory(a.source, dir)
+	err := copyDirectory(a.workingDir, dir)
 	if err != nil {
 		a.fatal(err)
 	}
@@ -42,10 +42,10 @@ func (a *PulumiTest) CopyTo(dir string, opts ...opttest.Option) *PulumiTest {
 		opt.Apply(options)
 	}
 	newTest := &PulumiTest{
-		t:       a.t,
-		ctx:     a.ctx,
-		source:  dir,
-		options: options,
+		t:          a.t,
+		ctx:        a.ctx,
+		workingDir: dir,
+		options:    options,
 	}
 	pulumiTestInit(newTest, options)
 	return newTest

--- a/pulumitest/install.go
+++ b/pulumitest/install.go
@@ -10,7 +10,7 @@ func (a *PulumiTest) Install() string {
 
 	a.t.Log("installing packages and plugins")
 	cmd := exec.Command("pulumi", "install")
-	cmd.Dir = a.source
+	cmd.Dir = a.workingDir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		a.fatalf("failed to install packages and plugins: %s\n%s", err, out)

--- a/pulumitest/newStack.go
+++ b/pulumitest/newStack.go
@@ -30,7 +30,7 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 	}
 
 	if stackName == "" {
-		stackName = randomStackName(pt.source)
+		stackName = randomStackName(pt.workingDir)
 	}
 
 	options := pt.options
@@ -82,7 +82,7 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 	stackOpts = append(stackOpts, stackOptions.Opts...)
 
 	pt.logf("creating stack %s", stackName)
-	stack, err := auto.NewStackLocalSource(pt.ctx, stackName, pt.source, stackOpts...)
+	stack, err := auto.NewStackLocalSource(pt.ctx, stackName, pt.workingDir, stackOpts...)
 
 	providerPluginPaths := options.ProviderPluginPaths()
 	if len(providerPluginPaths) > 0 {
@@ -134,7 +134,7 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 	if options.YarnLinks != nil && len(options.YarnLinks) > 0 {
 		for _, pkg := range options.YarnLinks {
 			cmd := exec.Command("yarn", "link", pkg)
-			cmd.Dir = pt.source
+			cmd.Dir = pt.workingDir
 			pt.logf("linking yarn package: %s", cmd)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
@@ -157,7 +157,7 @@ func (pt *PulumiTest) NewStack(stackName string, opts ...optnewstack.NewStackOpt
 			}
 			replacement := fmt.Sprintf("%s=%s", old, absPath)
 			cmd := exec.Command("go", "mod", "edit", "-replace", replacement)
-			cmd.Dir = pt.source
+			cmd.Dir = pt.workingDir
 			pt.logf("adding go.mod replacement: %s", cmd)
 			out, err := cmd.CombinedOutput()
 			if err != nil {

--- a/pulumitest/pulumiTest.go
+++ b/pulumitest/pulumiTest.go
@@ -11,7 +11,7 @@ import (
 type PulumiTest struct {
 	t            PT
 	ctx          context.Context
-	source       string
+	workingDir   string
 	options      *opttest.Options
 	currentStack *auto.Stack
 }
@@ -29,10 +29,10 @@ func NewPulumiTest(t PT, source string, opts ...opttest.Option) *PulumiTest {
 		opt.Apply(options)
 	}
 	pt := &PulumiTest{
-		t:       t,
-		ctx:     ctx,
-		source:  source,
-		options: options,
+		t:          t,
+		ctx:        ctx,
+		workingDir: source,
+		options:    options,
 	}
 	if !options.TestInPlace {
 		pt = pt.CopyToTempDir()
@@ -66,9 +66,15 @@ func pulumiTestInit(pt *PulumiTest, options *opttest.Options) {
 	}
 }
 
-// Source returns the current source directory.
+// Deprecated: Use WorkingDir instead.
+// Source returns the current working directory.
 func (a *PulumiTest) Source() string {
-	return a.source
+	return a.workingDir
+}
+
+// WorkingDir returns the current working directory.
+func (a *PulumiTest) WorkingDir() string {
+	return a.workingDir
 }
 
 // Context returns the current context.Context instance used for automation API calls.

--- a/pulumitest/updateSource.go
+++ b/pulumitest/updateSource.go
@@ -8,7 +8,7 @@ func (a *PulumiTest) UpdateSource(pathElems ...string) {
 
 	path := filepath.Join(pathElems...)
 	a.logf("updating source from %s", path)
-	err := copyDirectory(path, a.source)
+	err := copyDirectory(path, a.workingDir)
 	if err != nil {
 		a.t.Log(err)
 		a.t.FailNow()


### PR DESCRIPTION
Source is slightly misleading as you might think this is pointing to the original directory the test was created from rather than the temporary directory where the code is now being run from.

- Leave public Source() property so this isn't a breaking change, but deprecate it.