### PR TITLE
Pass `T` explicitly to all methods

### DIFF
--- a/previewProviderUpgrade.go
+++ b/previewProviderUpgrade.go
@@ -17,18 +17,18 @@ import (
 // Uses a default cache directory of "testdata/recorded/TestProviderUpgrade/{programName}/{baselineVersion}".
 func PreviewProviderUpgrade(t pulumitest.PT, pulumiTest *pulumitest.PulumiTest, providerName string, baselineVersion string, opts ...optproviderupgrade.PreviewProviderUpgradeOpt) auto.PreviewResult {
 	t.Helper()
-	previewTest := pulumiTest.CopyToTempDir(opttest.NewStackOptions(optnewstack.DisableAutoDestroy()))
+	previewTest := pulumiTest.CopyToTempDir(t, opttest.NewStackOptions(optnewstack.DisableAutoDestroy()))
 	options := optproviderupgrade.Defaults()
 	for _, opt := range opts {
 		opt.Apply(&options)
 	}
 	programName := filepath.Base(pulumiTest.Source())
 	cacheDir := getCacheDir(options, programName, baselineVersion)
-	previewTest.Run(
+	previewTest.Run(t,
 		func(test *pulumitest.PulumiTest) {
 			t.Helper()
-			test.Up()
-			grptLog := test.GrpcLog()
+			test.Up(t)
+			grptLog := test.GrpcLog(t)
 			grpcLogPath := filepath.Join(cacheDir, "grpc.json")
 			t.Log(fmt.Sprintf("writing grpc log to %s", grpcLogPath))
 			grptLog.WriteTo(grpcLogPath)
@@ -41,9 +41,9 @@ func PreviewProviderUpgrade(t pulumitest.PT, pulumiTest *pulumitest.PulumiTest, 
 	)
 
 	if options.NewSourcePath != "" {
-		previewTest.UpdateSource(options.NewSourcePath)
+		previewTest.UpdateSource(t, options.NewSourcePath)
 	}
-	return previewTest.Preview()
+	return previewTest.Preview(t)
 }
 
 func baselineProviderOpt(options optproviderupgrade.PreviewProviderUpgradeOptions, providerName string, baselineVersion string) opttest.Option {

--- a/providers/providerInterceptProxy_test.go
+++ b/providers/providerInterceptProxy_test.go
@@ -41,6 +41,6 @@ func TestProviderInterceptProxy(t *testing.T) {
 		filepath.Join("..", "pulumitest", "testdata", "yaml_azure"),
 		opttest.AttachProvider("azure-native", interceptedFactory))
 
-	test.Preview()
+	test.Preview(t)
 	assert.True(t, didAttach, "expected Attach to be called in proxy")
 }

--- a/providers/providerMock_test.go
+++ b/providers/providerMock_test.go
@@ -22,7 +22,7 @@ func TestProviderMock(t *testing.T) {
 		test := pulumitest.NewPulumiTest(t, source,
 			opttest.AttachProvider("gcp",
 				providers.ProviderMockFactory(providers.ProviderMocks{})))
-		test.Preview()
+		test.Preview(t)
 	})
 
 	t.Run("with mocks", func(t *testing.T) {
@@ -60,8 +60,8 @@ func TestProviderMock(t *testing.T) {
 						return &emptypb.Empty{}, nil
 					},
 				})))
-		test.Preview()
-		test.Up()
+		test.Preview(t)
+		test.Up(t)
 		assert.True(t, attached, "expected Attach to be called in mock")
 		assert.True(t, configured, "expected Configure to be called in mock")
 		assert.True(t, checkedConfig, "expected CheckConfig to be called in mock")

--- a/pulumitest/convert.go
+++ b/pulumitest/convert.go
@@ -18,23 +18,23 @@ type ConvertResult struct {
 
 // Convert a program to a given language.
 // It returns a new PulumiTest instance for the converted program which will be outputted into a temporary directory.
-func (a *PulumiTest) Convert(language string, opts ...opttest.Option) ConvertResult {
-	a.t.Helper()
+func (a *PulumiTest) Convert(t PT, language string, opts ...opttest.Option) ConvertResult {
+	t.Helper()
 
-	tempDir := a.t.TempDir()
+	tempDir := t.TempDir()
 	base := filepath.Base(a.workingDir)
 	targetDir := filepath.Join(tempDir, fmt.Sprintf("%s-%s", base, language))
 	err := os.Mkdir(targetDir, 0755)
 	if err != nil {
-		a.fatal(err)
+		ptFatal(t, err)
 	}
 
-	a.logf("converting to %s", language)
+	ptLogF(t, "converting to %s", language)
 	cmd := exec.Command("pulumi", "convert", "--language", language, "--generate-only", "--out", targetDir)
 	cmd.Dir = a.workingDir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		a.fatalf("failed to convert directory: %s\n%s", err, out)
+		ptFatalF(t, "failed to convert directory: %s\n%s", err, out)
 	}
 
 	options := a.options.Copy()
@@ -43,12 +43,11 @@ func (a *PulumiTest) Convert(language string, opts ...opttest.Option) ConvertRes
 	}
 
 	convertedTest := &PulumiTest{
-		t:          a.t,
 		ctx:        a.ctx,
 		workingDir: targetDir,
 		options:    options,
 	}
-	pulumiTestInit(convertedTest, options)
+	pulumiTestInit(t, convertedTest, options)
 	return ConvertResult{
 		PulumiTest: convertedTest,
 		Output:     string(out),

--- a/pulumitest/copy.go
+++ b/pulumitest/copy.go
@@ -12,29 +12,29 @@ import (
 // CopyToTempDir copies the program to a temporary directory.
 // It returns a new PulumiTest instance for the copied program.
 // This is used to avoid temporary files being written to the source directory.
-func (a *PulumiTest) CopyToTempDir(opts ...opttest.Option) *PulumiTest {
-	a.t.Helper()
-	tempDir := tempDirWithoutCleanupOnFailedTest(a.t, "programDir")
+func (a *PulumiTest) CopyToTempDir(t PT, opts ...opttest.Option) *PulumiTest {
+	t.Helper()
+	tempDir := tempDirWithoutCleanupOnFailedTest(t, "programDir")
 
 	// Maintain the directory name in the temp dir as this might be used for stack naming.
 	sourceBase := filepath.Base(a.workingDir)
 	destination := filepath.Join(tempDir, sourceBase)
 	err := os.Mkdir(destination, 0755)
 	if err != nil {
-		a.fatal(err)
+		ptFatal(t, err)
 	}
 
-	return a.CopyTo(destination, opts...)
+	return a.CopyTo(t, destination, opts...)
 }
 
 // CopyTo copies the program to the specified directory.
 // It returns a new PulumiTest instance for the copied program.
-func (a *PulumiTest) CopyTo(dir string, opts ...opttest.Option) *PulumiTest {
-	a.t.Helper()
+func (a *PulumiTest) CopyTo(t PT, dir string, opts ...opttest.Option) *PulumiTest {
+	t.Helper()
 
 	err := copyDirectory(a.workingDir, dir)
 	if err != nil {
-		a.fatal(err)
+		ptFatal(t, err)
 	}
 
 	options := a.options.Copy()
@@ -42,12 +42,11 @@ func (a *PulumiTest) CopyTo(dir string, opts ...opttest.Option) *PulumiTest {
 		opt.Apply(options)
 	}
 	newTest := &PulumiTest{
-		t:          a.t,
 		ctx:        a.ctx,
 		workingDir: dir,
 		options:    options,
 	}
-	pulumiTestInit(newTest, options)
+	pulumiTestInit(t, newTest, options)
 	return newTest
 }
 

--- a/pulumitest/destroy.go
+++ b/pulumitest/destroy.go
@@ -6,19 +6,19 @@ import (
 )
 
 // Up deploys the current stack.
-func (a *PulumiTest) Destroy(opts ...optdestroy.Option) auto.DestroyResult {
-	a.t.Helper()
+func (a *PulumiTest) Destroy(t PT, opts ...optdestroy.Option) auto.DestroyResult {
+	t.Helper()
 
-	a.t.Log("destroying")
+	t.Log("destroying")
 	if a.currentStack == nil {
-		a.fatal("no current stack")
+		ptFatal(t, "no current stack")
 	}
 	if !a.options.DisableGrpcLog {
-		a.ClearGrpcLog()
+		a.ClearGrpcLog(t)
 	}
 	result, err := a.currentStack.Destroy(a.ctx, opts...)
 	if err != nil {
-		a.fatalf("failed to destroy: %s", err)
+		ptFatalF(t, "failed to destroy: %s", err)
 	}
 	return result
 }

--- a/pulumitest/destroy_test.go
+++ b/pulumitest/destroy_test.go
@@ -9,6 +9,6 @@ import (
 func TestDestroy(t *testing.T) {
 	t.Parallel()
 	test := pulumitest.NewPulumiTest(t, "testdata/yaml_program")
-	test.Up()
-	test.Destroy()
+	test.Up(t)
+	test.Destroy(t)
 }

--- a/pulumitest/execCmd.go
+++ b/pulumitest/execCmd.go
@@ -7,14 +7,14 @@ import (
 )
 
 type cmdOutput struct {
-	Args  []string
-	Stdout string
-	Stderr string
+	Args       []string
+	Stdout     string
+	Stderr     string
 	ReturnCode int
 }
 
-func (a *PulumiTest) execCmd(args ...string) cmdOutput {
-	a.t.Helper()
+func (a *PulumiTest) execCmd(t PT, args ...string) cmdOutput {
+	t.Helper()
 	workspace := a.CurrentStack().Workspace()
 	ctx := context.Background()
 	workdir := workspace.WorkDir()
@@ -26,16 +26,15 @@ func (a *PulumiTest) execCmd(args ...string) cmdOutput {
 
 	s1, s2, code, err := workspace.PulumiCommand().Run(ctx, workdir, stdin, nil, nil, env, args...)
 	if err != nil {
-		a.logf(s1)
-		a.logf(s2)
-		a.fatalf("Failed to run command %v: %v", args, err)
+		ptLogF(t, s1)
+		ptLogF(t, s2)
+		ptFatalF(t, "Failed to run command %v: %v", args, err)
 	}
 
 	return cmdOutput{
-		Args: args,
-		Stdout: s1,
-		Stderr: s2,
+		Args:       args,
+		Stdout:     s1,
+		Stderr:     s2,
 		ReturnCode: code,
 	}
 }
-

--- a/pulumitest/exportStack.go
+++ b/pulumitest/exportStack.go
@@ -5,16 +5,16 @@ import (
 )
 
 // ExportStack exports the current stack state.
-func (a *PulumiTest) ExportStack() apitype.UntypedDeployment {
-	a.t.Helper()
+func (a *PulumiTest) ExportStack(t PT) apitype.UntypedDeployment {
+	t.Helper()
 
-	a.t.Log("exporting stack")
+	t.Log("exporting stack")
 	if a.currentStack == nil {
-		a.fatal("no current stack")
+		ptFatal(t, "no current stack")
 	}
 	out, err := a.currentStack.Workspace().ExportStack(a.Context(), a.currentStack.Name())
 	if err != nil {
-		a.fatalf("failed to export stack: %s", err)
+		ptFatalF(t, "failed to export stack: %s", err)
 	}
 	return out
 }

--- a/pulumitest/grpcLog.go
+++ b/pulumitest/grpcLog.go
@@ -7,34 +7,35 @@ import (
 )
 
 // GrpcLog reads the gRPC log for the current stack based on the PULUMI_DEBUG_GRPC env var.
-func (pt *PulumiTest) GrpcLog() *grpclog.GrpcLog {
-	pt.t.Helper()
+func (pt *PulumiTest) GrpcLog(t PT) *grpclog.GrpcLog {
+	t.Helper()
 
 	if pt.currentStack == nil {
-		pt.t.Log("can't read gRPC log: no current stack")
+		t.Log("can't read gRPC log: no current stack")
 		return nil
 	}
 
 	env := pt.CurrentStack().Workspace().GetEnvVars()
 	if env == nil || env["PULUMI_DEBUG_GRPC"] == "" {
-		pt.t.Log("can't read gRPC log: PULUMI_DEBUG_GRPC env var not set")
+		t.Log("can't read gRPC log: PULUMI_DEBUG_GRPC env var not set")
 		return nil
 	}
 
 	log, err := grpclog.LoadLog(env["PULUMI_DEBUG_GRPC"])
 	if err != nil {
-		pt.fatalf("failed to load grpc log: %s", err)
+		ptFatalF(t, "failed to load grpc log: %s", err)
 	}
 	return log
 }
 
 // ClearGrpcLog clears the gRPC log for the current stack based on the PULUMI_DEBUG_GRPC env var.
-func (pt *PulumiTest) ClearGrpcLog() {
+func (pt *PulumiTest) ClearGrpcLog(t PT) {
+	t.Helper()
 	env := pt.CurrentStack().Workspace().GetEnvVars()
 	if env == nil || env["PULUMI_DEBUG_GRPC"] == "" {
 		return
 	}
 	if err := os.RemoveAll(env["PULUMI_DEBUG_GRPC"]); err != nil {
-		pt.fatalf("failed to clear gRPC log: %s", err)
+		ptFatalF(t, "failed to clear gRPC log: %s", err)
 	}
 }

--- a/pulumitest/grpcLog_test.go
+++ b/pulumitest/grpcLog_test.go
@@ -12,8 +12,8 @@ import (
 func TestGrpc(t *testing.T) {
 	t.Parallel()
 	test := pulumitest.NewPulumiTest(t, "testdata/yaml_program")
-	test.Up()
-	log := test.GrpcLog()
+	test.Up(t)
+	log := test.GrpcLog(t)
 	assert.NotEmpty(t, log)
 	creates, err := log.Creates()
 	assert.NoError(t, err)

--- a/pulumitest/import.go
+++ b/pulumitest/import.go
@@ -1,9 +1,7 @@
 package pulumitest
 
-func (a *PulumiTest) Import(
-	resourceType, resourceName, resourceID string, providerUrn string, args ...string,
-) cmdOutput {
-	a.t.Helper()
+func (a *PulumiTest) Import(t PT, resourceType, resourceName, resourceID string, providerUrn string, args ...string) cmdOutput {
+	t.Helper()
 	arguments := []string{
 		"import", resourceType, resourceName, resourceID, "--yes", "--protect=false", "-s", a.CurrentStack().Name(),
 	}
@@ -11,10 +9,10 @@ func (a *PulumiTest) Import(
 		arguments = append(arguments, "--provider="+providerUrn)
 	}
 	arguments = append(arguments, args...)
-	ret := a.execCmd(arguments...)
+	ret := a.execCmd(t, arguments...)
 	if ret.ReturnCode != 0 {
-		a.log(ret.Stdout)
-		a.fatalf("failed to import resource %s: %s", resourceName, ret.Stderr)
+		t.Log(ret.Stdout)
+		ptFatalF(t, "failed to import resource %s: %s", resourceName, ret.Stderr)
 	}
 
 	return ret

--- a/pulumitest/importStack.go
+++ b/pulumitest/importStack.go
@@ -5,15 +5,15 @@ import (
 )
 
 // ImportStack imports the given stack state into the test's current stack.
-func (a *PulumiTest) ImportStack(source apitype.UntypedDeployment) {
-	a.t.Helper()
+func (a *PulumiTest) ImportStack(t PT, source apitype.UntypedDeployment) {
+	t.Helper()
 
-	a.t.Log("importing stack")
+	t.Log("importing stack")
 	if a.currentStack == nil {
-		a.fatal("no current stack")
+		ptFatal(t, "no current stack")
 	}
 	err := a.currentStack.Workspace().ImportStack(a.Context(), a.currentStack.Name(), source)
 	if err != nil {
-		a.fatalf("failed to import stack: %s", err)
+		ptFatalF(t, "failed to import stack: %s", err)
 	}
 }

--- a/pulumitest/import_test.go
+++ b/pulumitest/import_test.go
@@ -15,13 +15,13 @@ func TestImport(t *testing.T) {
 	t.Parallel()
 	test := pulumitest.NewPulumiTest(t, "testdata/yaml_empty")
 
-	res := test.Import("random:index/randomString:RandomString", "str", "importedString", "")
+	res := test.Import(t, "random:index/randomString:RandomString", "str", "importedString", "")
 
 	// Assert on the generated YAML containing a resource definition
 	require.Contains(t, res.Stdout, "type: random:RandomString")
 
 	// Assert on the stack containing the resource state
-	stack := test.ExportStack()
+	stack := test.ExportStack(t)
 	data, err := stack.Deployment.MarshalJSON()
 	require.NoError(t, err)
 	var stateMap map[string]interface{}
@@ -47,7 +47,7 @@ func TestImportWithArgs(t *testing.T) {
 	test := pulumitest.NewPulumiTest(t, "testdata/yaml_empty")
 
 	outFile := filepath.Join(test.CurrentStack().Workspace().WorkDir(), "out.yaml")
-	res := test.Import("random:index/randomString:RandomString", "str", "importedString", "", "--out", outFile)
+	res := test.Import(t, "random:index/randomString:RandomString", "str", "importedString", "", "--out", outFile)
 
 	assert.Equal(t, []string{
 		"import",
@@ -62,7 +62,7 @@ func TestImportWithArgs(t *testing.T) {
 	assert.Contains(t, string(contents), "type: random:RandomString")
 
 	// Assert on the stack containing the resource state
-	stack := test.ExportStack()
+	stack := test.ExportStack(t)
 	data, err := stack.Deployment.MarshalJSON()
 	require.NoError(t, err)
 	var stateMap map[string]interface{}

--- a/pulumitest/install.go
+++ b/pulumitest/install.go
@@ -5,15 +5,15 @@ import (
 )
 
 // Install installs packages and plugins for a given directory by running `pulumi install`.
-func (a *PulumiTest) Install() string {
-	a.t.Helper()
+func (a *PulumiTest) Install(t PT) string {
+	t.Helper()
 
-	a.t.Log("installing packages and plugins")
+	t.Log("installing packages and plugins")
 	cmd := exec.Command("pulumi", "install")
 	cmd.Dir = a.workingDir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		a.fatalf("failed to install packages and plugins: %s\n%s", err, out)
+		ptFatalF(t, "failed to install packages and plugins: %s\n%s", err, out)
 	}
 	return string(out)
 }

--- a/pulumitest/installStack.go
+++ b/pulumitest/installStack.go
@@ -5,10 +5,10 @@ import (
 )
 
 // InstallStack installs packages, and creates a new stack.
-func (pt *PulumiTest) InstallStack(stackName string, opts ...optnewstack.NewStackOpt) *PulumiTest {
-	pt.t.Helper()
+func (pt *PulumiTest) InstallStack(t PT, stackName string, opts ...optnewstack.NewStackOpt) *PulumiTest {
+	t.Helper()
 
-	pt.Install()
-	pt.NewStack(stackName, opts...)
+	pt.Install(t)
+	pt.NewStack(t, stackName, opts...)
 	return pt
 }

--- a/pulumitest/installStack_test.go
+++ b/pulumitest/installStack_test.go
@@ -13,7 +13,7 @@ func TestInstallStack(t *testing.T) {
 	test := pulumitest.NewPulumiTest(t, "testdata/yaml_program", opttest.SkipInstall(), opttest.SkipStackCreate())
 	assert.Nil(t, test.CurrentStack())
 
-	test.InstallStack("teststack")
+	test.InstallStack(t, "teststack")
 
 	assert.Equal(t, "teststack", test.CurrentStack().Name())
 }

--- a/pulumitest/preview.go
+++ b/pulumitest/preview.go
@@ -6,19 +6,19 @@ import (
 )
 
 // Preview previews an update to the current stack.
-func (a *PulumiTest) Preview(opts ...optpreview.Option) auto.PreviewResult {
-	a.t.Helper()
+func (a *PulumiTest) Preview(t PT, opts ...optpreview.Option) auto.PreviewResult {
+	t.Helper()
 
-	a.t.Log("previewing update")
+	t.Log("previewing update")
 	if a.currentStack == nil {
-		a.fatal("no current stack")
+		ptFatal(t, "no current stack")
 	}
 	if !a.options.DisableGrpcLog {
-		a.ClearGrpcLog()
+		a.ClearGrpcLog(t)
 	}
 	result, err := a.currentStack.Preview(a.ctx, opts...)
 	if err != nil {
-		a.fatalf("failed to preview update: %s", err)
+		ptFatalF(t, "failed to preview update: %s", err)
 	}
 	return result
 }

--- a/pulumitest/pulumiTest.go
+++ b/pulumitest/pulumiTest.go
@@ -2,14 +2,12 @@ package pulumitest
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 )
 
 type PulumiTest struct {
-	t            PT
 	ctx          context.Context
 	workingDir   string
 	options      *opttest.Options
@@ -29,15 +27,14 @@ func NewPulumiTest(t PT, source string, opts ...opttest.Option) *PulumiTest {
 		opt.Apply(options)
 	}
 	pt := &PulumiTest{
-		t:          t,
 		ctx:        ctx,
 		workingDir: source,
 		options:    options,
 	}
 	if !options.TestInPlace {
-		pt = pt.CopyToTempDir()
+		pt = pt.CopyToTempDir(t)
 	} else {
-		pulumiTestInit(pt, options)
+		pulumiTestInit(t, pt, options)
 	}
 	return pt
 }
@@ -56,13 +53,13 @@ func testContext(t PT) context.Context {
 }
 
 // Perform the common initialization steps for a PulumiTest instance.
-func pulumiTestInit(pt *PulumiTest, options *opttest.Options) {
-	pt.t.Helper()
+func pulumiTestInit(t PT, pt *PulumiTest, options *opttest.Options) {
+	t.Helper()
 	if !options.SkipInstall {
-		pt.Install()
+		pt.Install(t)
 	}
 	if !options.SkipStackCreate {
-		pt.NewStack(options.StackName, options.NewStackOpts...)
+		pt.NewStack(t, options.StackName, options.NewStackOpts...)
 	}
 }
 
@@ -85,32 +82,4 @@ func (a *PulumiTest) Context() context.Context {
 // CurrentStack returns the last stack that was created or nil if no stack has been created yet.
 func (a *PulumiTest) CurrentStack() *auto.Stack {
 	return a.currentStack
-}
-
-func (a *PulumiTest) logf(format string, args ...any) {
-	a.t.Helper()
-	a.t.Log(fmt.Sprintf(format, args...))
-}
-
-func (a *PulumiTest) log(args ...any) {
-	a.t.Helper()
-	a.t.Log(args...)
-}
-
-func (a *PulumiTest) errorf(format string, args ...any) {
-	a.t.Helper()
-	a.t.Log(fmt.Sprintf(format, args...))
-	a.t.Fail()
-}
-
-func (a *PulumiTest) fatalf(format string, args ...any) {
-	a.t.Helper()
-	a.t.Log(fmt.Sprintf(format, args...))
-	a.t.FailNow()
-}
-
-func (a *PulumiTest) fatal(args ...any) {
-	a.t.Helper()
-	a.t.Log(args...)
-	a.t.FailNow()
 }

--- a/pulumitest/pulumiTest_test.go
+++ b/pulumitest/pulumiTest_test.go
@@ -18,26 +18,26 @@ func TestDeploy(t *testing.T) {
 	test := NewPulumiTest(t, filepath.Join("testdata", "yaml_program"), opttest.SkipInstall(), opttest.SkipStackCreate())
 
 	// Ensure dependencies are installed.
-	test.Install()
+	test.Install(t)
 	// Create a new stack with auto-naming.
-	test.NewStack("")
+	test.NewStack(t, "")
 
 	// Test a preview.
-	yamlPreview := test.Preview()
+	yamlPreview := test.Preview(t)
 	assert.Equal(t,
 		map[apitype.OpType]int{apitype.OpCreate: 2},
 		yamlPreview.ChangeSummary)
 	// Now do a real deploy.
-	yamlUp := test.Up()
+	yamlUp := test.Up(t)
 	assert.Equal(t,
 		map[string]int{"create": 2},
 		*yamlUp.Summary.ResourceChanges)
 
 	// Export the stack state.
-	yamlStack := test.ExportStack()
-	test.ImportStack(yamlStack)
+	yamlStack := test.ExportStack(t)
+	test.ImportStack(t, yamlStack)
 
-	yamlPreview2 := test.Preview()
+	yamlPreview2 := test.Preview(t)
 	assertpreview.HasNoChanges(t, yamlPreview2)
 }
 
@@ -47,18 +47,18 @@ func TestConvert(t *testing.T) {
 	source := NewPulumiTest(t, filepath.Join("testdata", "yaml_program"), opttest.TestInPlace())
 
 	// Convert the original source to Python.
-	converted := source.Convert("python").PulumiTest
+	converted := source.Convert(t, "python").PulumiTest
 	assert.NotEqual(t, converted.Source(), source.Source())
 
-	converted.Install()
-	converted.NewStack("test")
+	converted.Install(t)
+	converted.NewStack(t, "test")
 
-	pythonPreview := converted.Preview()
+	pythonPreview := converted.Preview(t)
 	assert.Equal(t,
 		map[apitype.OpType]int{apitype.OpCreate: 2},
 		pythonPreview.ChangeSummary)
 
-	pythonUp := converted.Up()
+	pythonUp := converted.Up(t)
 	assert.Equal(t,
 		map[string]int{"create": 2},
 		*pythonUp.Summary.ResourceChanges)
@@ -72,8 +72,8 @@ func TestConvert(t *testing.T) {
 func TestGrpcLog(t *testing.T) {
 	t.Parallel()
 	test := NewPulumiTest(t, filepath.Join("testdata", "yaml_program"))
-	test.Preview()
-	grpcLog := test.GrpcLog()
+	test.Preview(t)
+	grpcLog := test.GrpcLog(t)
 	creates, err := grpcLog.Creates()
 	assert.NoError(t, err, "expected no error when reading creates from grpc log")
 	assert.Equal(t, 1, len(creates))
@@ -127,7 +127,7 @@ func TestSkipStackCreateInPlace(t *testing.T) {
 func TestProviderPluginPath(t *testing.T) {
 	t.Parallel()
 	test := NewPulumiTest(t, filepath.Join("testdata", "yaml_program"), opttest.DownloadProviderVersion("random", "4.15.0"))
-	test.Preview()
+	test.Preview(t)
 
 	settings, err := test.CurrentStack().Workspace().ProjectSettings(test.Context())
 	assert.NoError(t, err, "expected no error when getting project settings")

--- a/pulumitest/refresh.go
+++ b/pulumitest/refresh.go
@@ -6,19 +6,19 @@ import (
 )
 
 // Refresh refreshes the current stack.
-func (a *PulumiTest) Refresh(opts ...optrefresh.Option) auto.RefreshResult {
-	a.t.Helper()
+func (a *PulumiTest) Refresh(t PT, opts ...optrefresh.Option) auto.RefreshResult {
+	t.Helper()
 
-	a.t.Log("refreshing")
+	t.Log("refreshing")
 	if a.currentStack == nil {
-		a.fatal("no current stack")
+		ptFatal(t, "no current stack")
 	}
 	if !a.options.DisableGrpcLog {
-		a.ClearGrpcLog()
+		a.ClearGrpcLog(t)
 	}
 	result, err := a.currentStack.Refresh(a.ctx, opts...)
 	if err != nil {
-		a.fatalf("failed to refresh: %s", err)
+		ptFatalF(t, "failed to refresh: %s", err)
 	}
 	return result
 }

--- a/pulumitest/refresh_test.go
+++ b/pulumitest/refresh_test.go
@@ -10,9 +10,9 @@ import (
 func TestRefresh(t *testing.T) {
 	t.Parallel()
 	test := pulumitest.NewPulumiTest(t, "testdata/yaml_program")
-	test.Up()
+	test.Up(t)
 
-	result := test.Refresh()
+	result := test.Refresh(t)
 
 	assertrefresh.HasNoChanges(t, result)
 }

--- a/pulumitest/run.go
+++ b/pulumitest/run.go
@@ -15,8 +15,8 @@ import (
 // Run will run the `execute` function in an isolated temp directory and with additional test options, then import the resulting stack state into the original test.
 // WithCache can be used to skip executing the run and return the cached stack state if available, or to cache the stack state after executing the run.
 // Options will be inherited from the original test, but can be added to with `optrun.WithOpts` or reset with `opttest.Defaults()`.
-func (pulumiTest *PulumiTest) Run(execute func(test *PulumiTest), opts ...optrun.Option) *PulumiTest {
-	pulumiTest.t.Helper()
+func (pulumiTest *PulumiTest) Run(t PT, execute func(test *PulumiTest), opts ...optrun.Option) *PulumiTest {
+	t.Helper()
 
 	options := optrun.DefaultOptions()
 	for _, o := range opts {
@@ -28,24 +28,24 @@ func (pulumiTest *PulumiTest) Run(execute func(test *PulumiTest), opts ...optrun
 	if options.EnableCache {
 		stackExport, err = tryReadStackExport(options.CachePath)
 		if err != nil {
-			pulumiTest.fatalf("failed to read stack export: %v", err)
+			ptFatalF(t, "failed to read stack export: %v", err)
 		}
 		if stackExport != nil {
-			pulumiTest.logf("run cache found at %s", options.CachePath)
+			ptLogF(t, "run cache found at %s", options.CachePath)
 		} else {
-			pulumiTest.logf("no run cache found at %s", options.CachePath)
+			ptLogF(t, "no run cache found at %s", options.CachePath)
 		}
 	}
 
 	if stackExport == nil {
-		isolatedTest := pulumiTest.CopyToTempDir(options.OptTest...)
+		isolatedTest := pulumiTest.CopyToTempDir(t, options.OptTest...)
 		execute(isolatedTest)
-		exportedStack := isolatedTest.ExportStack()
+		exportedStack := isolatedTest.ExportStack(t)
 		if options.EnableCache {
-			isolatedTest.logf("writing stack state to %s", options.CachePath)
+			ptLogF(t, "writing stack state to %s", options.CachePath)
 			err = writeStackExport(options.CachePath, &exportedStack, false /* overwrite */)
 			if err != nil {
-				isolatedTest.fatalf("failed to write snapshot to %s: %v", options.CachePath, err)
+				ptFatalF(t, "failed to write snapshot to %s: %v", options.CachePath, err)
 			}
 		}
 		stackExport = &exportedStack
@@ -55,17 +55,17 @@ func (pulumiTest *PulumiTest) Run(execute func(test *PulumiTest), opts ...optrun
 	stackName := pulumiTest.CurrentStack().Name()
 	fixedStack, err := fixupStackName(stackExport, stackName)
 	if err != nil {
-		pulumiTest.fatalf("failed to fixup stack name: %v", err)
+		ptFatalF(t, "failed to fixup stack name: %v", err)
 	}
 	if fixedStack != stackExport {
-		pulumiTest.logf("updating snapshot with fixed stack name: %s", stackName)
+		ptLogF(t, "updating snapshot with fixed stack name: %s", stackName)
 		err = writeStackExport(options.CachePath, fixedStack, true /* overwrite */)
 		if err != nil {
-			pulumiTest.fatalf("failed to write snapshot to %s: %v", options.CachePath, err)
+			ptFatalF(t, "failed to write snapshot to %s: %v", options.CachePath, err)
 		}
 		stackExport = fixedStack
 	}
-	pulumiTest.ImportStack(*stackExport)
+	pulumiTest.ImportStack(t, *stackExport)
 	return pulumiTest
 }
 

--- a/pulumitest/run_test.go
+++ b/pulumitest/run_test.go
@@ -16,10 +16,11 @@ func TestRunInIsolation(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		t.Parallel()
 		test := pulumitest.NewPulumiTest(t, filepath.Join("testdata", "yaml_program"))
-		test.Run(func(test *pulumitest.PulumiTest) {
-			test.Up()
+		test.Run(t, func(test *pulumitest.PulumiTest) {
+			test.Up(t)
 		})
-		preview := test.Preview()
+
+		preview := test.Preview(t)
 		assertpreview.HasNoChanges(t, preview)
 	})
 
@@ -27,11 +28,11 @@ func TestRunInIsolation(t *testing.T) {
 		t.Parallel()
 		test := pulumitest.NewPulumiTest(t, filepath.Join("testdata", "yaml_program"))
 		// Disable the gRPC log to ensure options are propagated correctly.
-		test.Run(func(test *pulumitest.PulumiTest) {
-			test.Up()
-			assert.Nil(t, test.GrpcLog(), "expected no grpc logs to be captured")
+		test.Run(t, func(test *pulumitest.PulumiTest) {
+			test.Up(t)
+			assert.Nil(t, test.GrpcLog(t), "expected no grpc logs to be captured")
 		}, optrun.WithOpts(opttest.DisableGrpcLog()))
-		test.Preview()
+		test.Preview(t)
 	})
 
 	t.Run("cached state", func(t *testing.T) {
@@ -41,18 +42,18 @@ func TestRunInIsolation(t *testing.T) {
 		cachePath := filepath.Join(cacheDir, "stack.yaml")
 
 		test1 := pulumitest.NewPulumiTest(t, filepath.Join("testdata", "yaml_program"))
-		test1.Run(func(test *pulumitest.PulumiTest) {
-			test.Up()
+		test1.Run(t, func(test *pulumitest.PulumiTest) {
+			test.Up(t)
 			cacheCalls++
 		}, optrun.WithCache(cachePath))
-		preview1 := test1.Preview()
+		preview1 := test1.Preview(t)
 
 		test2 := pulumitest.NewPulumiTest(t, filepath.Join("testdata", "yaml_program"))
-		test2.Run(func(test *pulumitest.PulumiTest) {
-			test.Up()
+		test2.Run(t, func(test *pulumitest.PulumiTest) {
+			test.Up(t)
 			cacheCalls++
 		}, optrun.WithCache(cachePath))
-		preview2 := test2.Preview()
+		preview2 := test2.Preview(t)
 
 		assert.Equal(t, 1, cacheCalls, "expected cached method to be called exactly once")
 		assert.Equal(t, preview1.ChangeSummary, preview2.ChangeSummary, "expected uncached and cached preview to be the same")
@@ -64,17 +65,17 @@ func TestRunInIsolation(t *testing.T) {
 		cachePath := filepath.Join(cacheDir, "stack.yaml")
 
 		test1 := pulumitest.NewPulumiTest(t, filepath.Join("testdata", "yaml_program"), opttest.StackName("stack-1"))
-		test1.Run(func(test *pulumitest.PulumiTest) {
-			test.Up()
+		test1.Run(t, func(test *pulumitest.PulumiTest) {
+			test.Up(t)
 		}, optrun.WithCache(cachePath))
-		preview1 := test1.Preview()
+		preview1 := test1.Preview(t)
 		assertpreview.HasNoChanges(t, preview1)
 
 		test2 := pulumitest.NewPulumiTest(t, filepath.Join("testdata", "yaml_program"))
-		test2.Run(func(test *pulumitest.PulumiTest) {
-			test.Up()
+		test2.Run(t, func(test *pulumitest.PulumiTest) {
+			test.Up(t)
 		}, optrun.WithCache(cachePath))
-		preview2 := test2.Preview()
+		preview2 := test2.Preview(t)
 		assertpreview.HasNoChanges(t, preview2)
 	})
 }

--- a/pulumitest/setConfig.go
+++ b/pulumitest/setConfig.go
@@ -2,14 +2,14 @@ package pulumitest
 
 import "github.com/pulumi/pulumi/sdk/v3/go/auto"
 
-func (a *PulumiTest) SetConfig(key, value string) {
-	a.t.Helper()
+func (a *PulumiTest) SetConfig(t PT, key, value string) {
+	t.Helper()
 
 	if a.currentStack == nil {
-		a.fatal("no current stack")
+		ptFatal(t, "no current stack")
 	}
 	err := a.currentStack.SetConfig(a.ctx, key, auto.ConfigValue{Value: value})
 	if err != nil {
-		a.fatalf("failed to set config: %s", err)
+		ptFatalF(t, "failed to set config: %s", err)
 	}
 }

--- a/pulumitest/setConfig_test.go
+++ b/pulumitest/setConfig_test.go
@@ -10,8 +10,8 @@ import (
 func TestSetConfig(t *testing.T) {
 	t.Parallel()
 	test := pulumitest.NewPulumiTest(t, "testdata/yaml_program_with_config")
-	test.SetConfig("passwordLength", "7")
-	result := test.Up()
+	test.SetConfig(t, "passwordLength", "7")
+	result := test.Up(t)
 
 	outputs := result.Outputs
 	assert.Len(t, outputs["password"].Value, 7)

--- a/pulumitest/testingT.go
+++ b/pulumitest/testingT.go
@@ -38,3 +38,20 @@ func ptFailed(t PT) bool {
 	}
 	return false
 }
+
+func ptLogF(t PT, format string, args ...any) {
+	t.Helper()
+	t.Log(fmt.Sprintf(format, args...))
+}
+
+func ptError(t PT, args ...any) {
+	t.Helper()
+	t.Log(args...)
+	t.Fail()
+}
+
+func ptFatal(t PT, args ...any) {
+	t.Helper()
+	t.Log(args...)
+	t.FailNow()
+}

--- a/pulumitest/up.go
+++ b/pulumitest/up.go
@@ -6,19 +6,19 @@ import (
 )
 
 // Up deploys the current stack.
-func (a *PulumiTest) Up(opts ...optup.Option) auto.UpResult {
-	a.t.Helper()
+func (a *PulumiTest) Up(t PT, opts ...optup.Option) auto.UpResult {
+	t.Helper()
 
-	a.t.Log("deploying")
+	t.Log("deploying")
 	if a.currentStack == nil {
-		a.fatal("no current stack")
+		ptFatal(t, "no current stack")
 	}
 	if !a.options.DisableGrpcLog {
-		a.ClearGrpcLog()
+		a.ClearGrpcLog(t)
 	}
 	result, err := a.currentStack.Up(a.ctx, opts...)
 	if err != nil {
-		a.fatalf("failed to deploy: %s", err)
+		ptFatalF(t, "failed to deploy: %s", err)
 	}
 	return result
 }

--- a/pulumitest/updateSource.go
+++ b/pulumitest/updateSource.go
@@ -3,14 +3,14 @@ package pulumitest
 import "path/filepath"
 
 // Copy files from a source directory to the current program directory.
-func (a *PulumiTest) UpdateSource(pathElems ...string) {
-	a.t.Helper()
+func (a *PulumiTest) UpdateSource(t PT, pathElems ...string) {
+	t.Helper()
 
 	path := filepath.Join(pathElems...)
-	a.logf("updating source from %s", path)
+	ptLogF(t, "updating source from %s", path)
 	err := copyDirectory(path, a.workingDir)
 	if err != nil {
-		a.t.Log(err)
-		a.t.FailNow()
+		t.Log(err)
+		t.FailNow()
 	}
 }

--- a/pulumitest/updateSource_test.go
+++ b/pulumitest/updateSource_test.go
@@ -25,9 +25,9 @@ func TestUpdateSourceError(t *testing.T) {
 
 	tt := &mockT{T: t}
 	test := pulumitest.NewPulumiTest(tt, "testdata/yaml_program")
-	test.UpdateSource("this-should-fail")
+	test.UpdateSource(tt, "this-should-fail")
 
-	assert.True(t, tt.Failed())
+	assert.True(tt, tt.Failed())
 }
 
 type mockT struct {

--- a/pulumitest/updateSource_test.go
+++ b/pulumitest/updateSource_test.go
@@ -10,10 +10,10 @@ import (
 func TestUpdateSource(t *testing.T) {
 	t.Parallel()
 	test := pulumitest.NewPulumiTest(t, "testdata/yaml_program")
-	test.Up()
+	test.Up(t)
 
-	test.UpdateSource("testdata/yaml_program_updated")
-	updated := test.Up()
+	test.UpdateSource(t, "testdata/yaml_program_updated")
+	updated := test.Up(t)
 
 	changes := *updated.Summary.ResourceChanges
 	assert.Equal(t, 1, changes["create"])


### PR DESCRIPTION
# ⚠️ Breaking change ⚠️ 

Don't capture T within the PulumiTest structure as this breaks various aspects of how Go's testing is designed:
1. Sub-tests are given their own `T` instance so if we create a copy of a `pulumitest` instance for a sub-test, we don't want logs reported to the parent.
2. Logs are incorrectly reported back to the wrong line number. The logs are tracked back to the construction of the `pulumitest` rather than the line of the operation that failed.

Fixes #104 

## Why pass in `T`?

1. Logging: We can automatically log significant context in case of failure.
2. Clean-up: When creating directories and stacks, we automatically register them for deletion after the test has passed.
3. Assertions: We automatically assert that operations are successful. 

## Solution

- Pass T as the first parameter for any method which does asserts internally as is the pattern in Go.
- Write an automated migration to update all existing usages of the library.

### Migration Script

We can fix pretty much all usages using `gofmt`.

```bash
gofmt -r 'a.Convert(b) -> a.Convert(t, b)' -w ./**/*_test.go
gofmt -r 'a.CopyTo(b) -> a.CopyTo(t, b)' -w ./**/*_test.go
gofmt -r 'a.CopyToTempDir() -> a.CopyToTempDir(t)' -w ./**/*_test.go
gofmt -r 'a.Destroy() -> a.Destroy(t)' -w ./**/*_test.go
gofmt -r 'a.ExportStack() -> a.ExportStack(t)' -w ./**/*_test.go
gofmt -r 'a.GrpcLog() -> a.GrpcLog(t)' -w ./**/*_test.go
gofmt -r 'a.ClearGrpcLog() -> a.ClearGrpcLog(t)' -w ./**/*_test.go
gofmt -r 'a.Import(b, c, d, e, f, g) -> a.Import(t, b, c, d, e, f, g)' -w ./**/*_test.go
gofmt -r 'a.Import(b, c, d, e, f) -> a.Import(t, b, c, d, e, f)' -w ./**/*_test.go
gofmt -r 'a.Import(b, c, d, e) -> a.Import(t, b, c, d, e)' -w ./**/*_test.go
gofmt -r 'a.Import(b, c, d) -> a.Import(t, b, c, d)' -w ./**/*_test.go
gofmt -r 'a.Import(b, c) -> a.Import(t, b, c)' -w ./**/*_test.go
gofmt -r 'a.Import(b) -> a.Import(t, b)' -w ./**/*_test.go
gofmt -r 'a.ImportStack(b) -> a.ImportStack(t, b)' -w ./**/*_test.go
gofmt -r 'a.Install() -> a.Install(t)' -w ./**/*_test.go
gofmt -r 'a.InstallStack(b) -> a.InstallStack(t, b)' -w ./**/*_test.go
gofmt -r 'a.Preview() -> a.Preview(t)' -w ./**/*_test.go
gofmt -r 'a.Refresh() -> a.Refresh(t)' -w ./**/*_test.go
gofmt -r 'a.SetConfig(b, c) -> a.SetConfig(t, b, c)' -w ./**/*_test.go
gofmt -r 'a.Up() -> a.Up(t)' -w ./**/*_test.go
gofmt -r 'a.UpdateSource(b) -> a.UpdateSource(t, b)' -w ./**/*_test.go
gofmt -r 'a.NewStack(b) -> a.NewStack(t, b)' -w ./**/*_test.go
gofmt -r 'a.Run(b) -> a.Run(t, b)' -w ./**/*_test.go
```

- It's a little messy but correctly migrates all usages within this package.
- ~`gofmt` seems unable to migrate the `pt.Run()` because it can't match inline functions~. Re-testing shows this works.
- The `Import` migration isn't idempotent due to the variable number of arguments so should be run once manually when upgrading to the new version and the changes committed.
- This doesn't handle any instances of passing additional functional argument, but I doubt we use many of these in practice.