### PR TITLE
Add `provider.ReplayInvokes`

### DIFF
--- a/previewProviderUpgrade.go
+++ b/previewProviderUpgrade.go
@@ -22,8 +22,8 @@ func PreviewProviderUpgrade(t pulumitest.PT, pulumiTest *pulumitest.PulumiTest, 
 	for _, opt := range opts {
 		opt.Apply(&options)
 	}
-	programName := filepath.Base(pulumiTest.Source())
-	cacheDir := getCacheDir(options, programName, baselineVersion)
+	programName := filepath.Base(pulumiTest.WorkingDir())
+	cacheDir := GetUpgradeCacheDir(programName, baselineVersion, options.CacheDirTemplate...)
 	previewTest.Run(t,
 		func(test *pulumitest.PulumiTest) {
 			t.Helper()
@@ -54,9 +54,15 @@ func baselineProviderOpt(options optproviderupgrade.PreviewProviderUpgradeOption
 	}
 }
 
-func getCacheDir(options optproviderupgrade.PreviewProviderUpgradeOptions, programName string, baselineVersion string) string {
+// GetUpgradeCacheDir returns the cache directory for a provider upgrade test.
+// If no cacheDirTemplatePath is provided, the default cache directory is used.
+func GetUpgradeCacheDir(programName, baselineVersion string, cacheDirTemplatePath ...string) string {
+	cacheDirTemplate := cacheDirTemplatePath
+	if len(cacheDirTemplate) == 0 {
+		cacheDirTemplate = optproviderupgrade.Defaults().CacheDirTemplate
+	}
 	var cacheDir string
-	for _, pathTemplateElement := range options.CacheDirTemplate {
+	for _, pathTemplateElement := range cacheDirTemplate {
 		switch pathTemplateElement {
 		case optproviderupgrade.ProgramName:
 			cacheDir = filepath.Join(cacheDir, programName)

--- a/previewProviderUpgrade_test.go
+++ b/previewProviderUpgrade_test.go
@@ -1,7 +1,6 @@
 package providertest_test
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -52,7 +51,7 @@ func TestPreviewWithInvokeReplayed(t *testing.T) {
 	cacheDir := t.TempDir()
 	commandProvider := providers.DownloadPluginBinaryFactory("command", "1.0.1")
 	// Intercept all invokes and replay them from a gRPC log during the preview.
-	commandProvider = commandProvider.ReplayInvokes(context.Background(), filepath.Join(cacheDir, "grpc.json"), false)
+	commandProvider = commandProvider.ReplayInvokes(filepath.Join(cacheDir, "grpc.json"), false)
 	test := pulumitest.NewPulumiTest(t, filepath.Join("pulumitest", "testdata", "yaml_command_invoke"),
 		opttest.AttachProvider("command", commandProvider))
 

--- a/providers/replayInvokes.go
+++ b/providers/replayInvokes.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/pulumi/providertest/grpclog"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -28,7 +29,9 @@ func (pf ProviderFactory) ReplayInvokes(ctx context.Context, grpcLogPath string,
 			// Avoid using range due to invokes containing sync locks.
 			for i := 0; i < len(invokes); i++ {
 				if invokes[i].Request.Tok == requestedToken {
-					return &invokes[i].Response, nil
+					if reflect.DeepEqual(in.Args.AsMap(), invokes[i].Request.Args.AsMap()) {
+						return &invokes[i].Response, nil
+					}
 				}
 			}
 			if allowLiveFallback {

--- a/providers/replayInvokes.go
+++ b/providers/replayInvokes.go
@@ -1,0 +1,41 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pulumi/providertest/grpclog"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+// ReplayInvokes wraps a provider factory, intercepting all invokes and replaying them from a gRPC log.
+// Example:
+// providerFactory := providers.ResourceProviderFactory(providerServer)
+// cacheDir := providertest.GetUpgradeCacheDir(filepath.Base(dir), "5.60.0")
+// factoryWithReplay := providerFactory.ReplayInvokes(ctx, filepath.Join(cacheDir, "grpc.json"), true)
+func (pf ProviderFactory) ReplayInvokes(ctx context.Context, grpcLogPath string, allowLiveFallback bool) ProviderFactory {
+	return ProviderInterceptFactory(ctx, pf, ProviderInterceptors{
+		Invoke: func(ctx context.Context, in *pulumirpc.InvokeRequest, client pulumirpc.ResourceProviderClient) (*pulumirpc.InvokeResponse, error) {
+			log, err := grpclog.LoadLog(grpcLogPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to load gRPC log: %w", err)
+			}
+			invokes, err := log.Invokes()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get invokes from log: %w", err)
+			}
+			requestedToken := in.GetTok()
+			// Avoid using range due to invokes containing sync locks.
+			for i := 0; i < len(invokes); i++ {
+				if invokes[i].Request.Tok == requestedToken {
+					return &invokes[i].Response, nil
+				}
+			}
+			if allowLiveFallback {
+				return client.Invoke(ctx, in)
+			} else {
+				return nil, fmt.Errorf("failed to find invoke %s in gRPC log", requestedToken)
+			}
+		},
+	})
+}

--- a/pulumitest/testdata/yaml_command_invoke/Pulumi.yaml
+++ b/pulumitest/testdata/yaml_command_invoke/Pulumi.yaml
@@ -1,17 +1,32 @@
 name: yaml_command_invoke
+description: This is used to test invoke replay.
 runtime: yaml
 variables:
   # Create a variable which always changes on every run
-  randomShellString:
+  randomShellString1:
     fn::invoke:
       function: command:local:run
       arguments:
         command: cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | head -c 10
+  # Create a second to check the args are deeply matched
+  # We therefore have a slightly different command so the command text isn't identical
+  randomShellString2:
+    fn::invoke:
+      function: command:local:run
+      arguments:
+        command: cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | head -c 20
 resources:
-  randomEchoResource:
+  randomEchoResource1:
     type: command:local:Command
     properties:
-      create: echo "Hello world!"
+      create: echo "${randomShellString1}"
       # Force this resource to be updated if the invoke changes which is easy to assert on in the preview result.
       triggers:
-        - ${randomShellString}
+        - ${randomShellString1}
+  randomEchoResource2:
+    type: command:local:Command
+    properties:
+      create: echo "${randomShellString2}"
+      # Force this resource to be updated if the invoke changes which is easy to assert on in the preview result.
+      triggers:
+        - ${randomShellString2}

--- a/pulumitest/testdata/yaml_command_invoke/Pulumi.yaml
+++ b/pulumitest/testdata/yaml_command_invoke/Pulumi.yaml
@@ -1,0 +1,17 @@
+name: yaml_command_invoke
+runtime: yaml
+variables:
+  # Create a variable which always changes on every run
+  randomShellString:
+    fn::invoke:
+      function: command:local:run
+      arguments:
+        command: cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | head -c 10
+resources:
+  randomEchoResource:
+    type: command:local:Command
+    properties:
+      create: echo "Hello world!"
+      # Force this resource to be updated if the invoke changes which is easy to assert on in the preview result.
+      triggers:
+        - ${randomShellString}


### PR DESCRIPTION
This allows PreviewProviderUpgrade to avoid side-effects from invokes which cause failures when the replay environment differs from the recording environment such as local vs CI.

- Allow wrapping a provider factory and intercept invokes to replay them from a log file.
- Expose `GetUpgradeCacheDir` so users don't have to hard code the whole long path themselves.

Closes https://github.com/pulumi/providertest/issues/43
Fixes https://github.com/pulumi/providertest/issues/31

### Example usage

```go
// Construct a provider factory as usual
providerFactory := providers.ResourceProviderFactory(providerServer)
// Locate where the gRPC logs were recorded
cacheDir := providertest.GetUpgradeCacheDir(filepath.Base(dir), "5.60.0")
// Intercept invoke calls and replay responses from the log file.
factoryWithReplay := providerFactory.ReplayInvokes(filepath.Join(cacheDir, "grpc.json"), true)
```