### PR TITLE
Failed test cleanup usability improvements

### DIFF
--- a/pulumitest/cleanup.go
+++ b/pulumitest/cleanup.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 )
 
+// We use this interesting contraption of immediately invoked callbacks to
+// eagerly calculate these variables but ensure they're not mutated.
+
 var skipDestroyOnFailure = (func() func() bool {
 	value, ok := os.LookupEnv("PULUMITEST_SKIP_DESTROY_ON_FAILURE")
 	skipDestroy := ok && strings.EqualFold(value, "true")
@@ -14,4 +17,17 @@ var skipDestroyOnFailure = (func() func() bool {
 var runningInCI = (func() func() bool {
 	_, ok := os.LookupEnv("CI")
 	return func() bool { return ok }
+})()
+
+var shouldRetainFilesOnFailure = (func() func() bool {
+	if value, ok := os.LookupEnv("PULUMITEST_RETAIN_FILES_ON_FAILURE"); ok {
+		if strings.EqualFold(value, "false") {
+			return func() bool { return false }
+		}
+		return func() bool { return true }
+	}
+	if skipDestroyOnFailure() {
+		return func() bool { return true }
+	}
+	return func() bool { return !runningInCI() }
 })()

--- a/pulumitest/cleanup.go
+++ b/pulumitest/cleanup.go
@@ -5,29 +5,23 @@ import (
 	"strings"
 )
 
-// We use this interesting contraption of immediately invoked callbacks to
-// eagerly calculate these variables but ensure they're not mutated.
-
-var skipDestroyOnFailure = (func() func() bool {
+func skipDestroyOnFailure() bool {
 	value, ok := os.LookupEnv("PULUMITEST_SKIP_DESTROY_ON_FAILURE")
 	skipDestroy := ok && strings.EqualFold(value, "true")
-	return func() bool { return skipDestroy }
-})()
+	return skipDestroy
+}
 
-var runningInCI = (func() func() bool {
+func runningInCI() bool {
 	_, ok := os.LookupEnv("CI")
-	return func() bool { return ok }
-})()
+	return ok
+}
 
-var shouldRetainFilesOnFailure = (func() func() bool {
+func shouldRetainFilesOnFailure() bool {
 	if value, ok := os.LookupEnv("PULUMITEST_RETAIN_FILES_ON_FAILURE"); ok {
-		if strings.EqualFold(value, "false") {
-			return func() bool { return false }
-		}
-		return func() bool { return true }
+		return !strings.EqualFold(value, "false")
 	}
 	if skipDestroyOnFailure() {
-		return func() bool { return true }
+		return true
 	}
-	return func() bool { return !runningInCI() }
-})()
+	return !runningInCI()
+}

--- a/pulumitest/tempdir.go
+++ b/pulumitest/tempdir.go
@@ -53,9 +53,14 @@ func tempDirWithoutCleanupOnFailedTest(t PT, desc string) string {
 		if c.tempDirErr == nil {
 			t.Cleanup(func() {
 				t.Helper()
-				if ptFailed(t) && !runningInCI() {
-					ptErrorF(t, "TempDir leaving %s to help debugging: %q", desc, c.tempDir)
-				} else if err := os.RemoveAll(c.tempDir); err != nil {
+				if ptFailed(t) && shouldRetainFilesOnFailure() {
+					ptLogF(t, "Skipping removal of %s temp directories on failures: %q", desc, c.tempDir)
+					t.Log("To remove these directories on failures, set PULUMITEST_RETAIN_FILES_ON_FAILURE=false")
+					return
+				}
+				err := os.RemoveAll(c.tempDir)
+				t.Log("Removed temp directories. To retain these, set PULUMITEST_RETAIN_FILES_ON_FAILURE=true")
+				if err != nil {
 					ptErrorF(t, "TempDir RemoveAll cleanup: %v", err)
 				}
 			})


### PR DESCRIPTION
Make cleaning up stacks easier 

- Print instructions on how to retain resources on failure.
- When retaining resources explain why this is happening and write out a destroy script for the user to run once they've finished their investigations.

Related to #109

Make temp directory cleanup easier to control 

- Maintain existing defaults - keeping files locally on failure by default.
- Add explicit control via PULUMITEST_RETAIN_FILES_ON_FAILURE with prompting to the user on failure.
- Default to retaining if we've retained the resources.
- Finally, check for the `CI` env var.