### PR TITLE
Show diffs for all previews

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,12 +29,5 @@
     "structpb",
     "Truef",
     "upstreamed"
-  ],
-  "workbench.colorCustomizations": {
-    "activityBar.background": "#302E25",
-    "titleBar.activeBackground": "#434033",
-    "titleBar.activeForeground": "#FAFAF9",
-    "statusBar.background": "#434033",
-    "statusBar.foreground": "#FAFAF9"
-  }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,5 +29,12 @@
     "structpb",
     "Truef",
     "upstreamed"
-  ]
+  ],
+  "workbench.colorCustomizations": {
+    "activityBar.background": "#302E25",
+    "titleBar.activeBackground": "#434033",
+    "titleBar.activeForeground": "#FAFAF9",
+    "statusBar.background": "#434033",
+    "statusBar.foreground": "#FAFAF9"
+  }
 }

--- a/previewProviderUpgrade.go
+++ b/previewProviderUpgrade.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pulumi/providertest/pulumitest/optrun"
 	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 )
 
 // PreviewProviderUpgrade captures the state of a stack from a baseline provider configuration, then previews the stack
@@ -44,7 +45,7 @@ func PreviewProviderUpgrade(t pulumitest.PT, pulumiTest *pulumitest.PulumiTest, 
 	if options.NewSourcePath != "" {
 		previewTest.UpdateSource(t, options.NewSourcePath)
 	}
-	return previewTest.Preview(t)
+	return previewTest.Preview(t, optpreview.Diff())
 }
 
 func baselineProviderOpt(options optproviderupgrade.PreviewProviderUpgradeOptions, providerName string, baselineVersion string) opttest.Option {

--- a/previewProviderUpgrade_test.go
+++ b/previewProviderUpgrade_test.go
@@ -43,7 +43,8 @@ func TestPreviewUpgradeWithKnownSourceEdit(t *testing.T) {
 		optproviderupgrade.NewSourcePath(filepath.Join("pulumitest", "testdata", "yaml_program_updated")),
 	)
 
-	assert.Contains(t, previewResult.StdOut, "random:index:RandomPassword password create")
+	assert.Contains(t, previewResult.StdOut, "random:index/randomPassword:RandomPassword::password")
+	assert.Contains(t, previewResult.StdOut, "+ 1 to create\n")
 }
 
 func TestPreviewWithInvokeReplayed(t *testing.T) {


### PR DESCRIPTION
Currently, a failing preview in a test just shows as something like
```
azure-native:storage:Blob myBlobFile create replacement [diff: ~source]
```

which is not as helpful as it could be diagnose the problem because you don't know _what_ the diff is.

We could expose a flag for an optional diff in `optproviderupgrade` but since this is a testing library, I suggest we skip this boilerplate and just turn the diff always on - when would you _not_ want to see the diff on test failure?

With this change:
```
            +-azure-native:storage:Blob: (replace)
                [id=/subscriptions/0282681f-7a9e-424b-80b2-96babd57a8a1/resourceGroups/rg1c1afbc6/providers/Microsoft.Storage/storageAccounts/store16dfec76/blobServices/default/containers/assets/blobs/mon-fichier.txt]
                [urn=urn:pulumi:test::upgrade-storage-blob::azure-native:storage:Blob::myBlobFile]
              - source: [secret]
              + source: asset(text:678e7ad) {
                    <contents elided>
                }
```