### PR TITLE
Fix secret identification

### DIFF
--- a/pulumitest/sanitize/sanitize.go
+++ b/pulumitest/sanitize/sanitize.go
@@ -18,10 +18,11 @@ import (
 	"encoding/json"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
 )
 
 const plaintextSub = "REDACTED BY PROVIDERTEST"
-const secretSignature = "4dabf18193072939515e22adb298388d"
+const sigKey = sig.Key
 
 // SanitizeSecretsInStackState sanitizes secrets in the stack state by replacing them with a placeholder.
 // secrets are identified by their magic signature, copied from pulumi/pulumi.
@@ -103,8 +104,8 @@ func sanitizeSecretsInObject(obj map[string]any, sanitizeSecret func(map[string]
 	for k, v := range obj {
 		innerObj, ok := v.(map[string]any)
 		if ok {
-			_, hasSecretSignature := innerObj[secretSignature]
-			if hasSecretSignature {
+			sigValue, hasSecretSignature := innerObj[sigKey]
+			if hasSecretSignature && sigValue == sig.Secret {
 				copy[k] = sanitizeSecret(innerObj)
 			} else {
 				copy[k] = sanitizeSecretsInObject(innerObj, sanitizeSecret)

--- a/pulumitest/sanitize/sanitize_test.go
+++ b/pulumitest/sanitize/sanitize_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestSanitizeSecretsInObject(t *testing.T) {
+
 	t.Parallel()
 
 	t.Run("simple", func(t *testing.T) {
@@ -88,10 +89,7 @@ func TestSanitizeSecretsInObject(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, input, sanitizeSecretsInObject(input, func(m map[string]any) map[string]any {
-			m["plaintext"] = "sanitized"
-			return m
-		}))
+		assert.Equal(t, input, sanitizeSecretsInObject(input, sanitizeStateSecret))
 	})
 }
 

--- a/pulumitest/sanitize/sanitize_test.go
+++ b/pulumitest/sanitize/sanitize_test.go
@@ -30,15 +30,15 @@ func TestSanitizeSecretsInObject(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		input := map[string]any{
 			"secondaryAccessKey": map[string]any{
-				secretSignature: "1b47061264138c4ac30d75fd1eb44270",
-				"plaintext":     "secret",
+				sigKey:      "1b47061264138c4ac30d75fd1eb44270",
+				"plaintext": "secret",
 			},
 		}
 
 		expected := map[string]any{
 			"secondaryAccessKey": map[string]any{
-				secretSignature: "1b47061264138c4ac30d75fd1eb44270",
-				"plaintext":     "sanitized",
+				sigKey:      "1b47061264138c4ac30d75fd1eb44270",
+				"plaintext": "sanitized",
 			},
 		}
 
@@ -54,8 +54,8 @@ func TestSanitizeSecretsInObject(t *testing.T) {
 			"foo": map[string]any{
 				"inner": map[string]any{
 					"secondaryAccessKey": map[string]any{
-						secretSignature: "1b47061264138c4ac30d75fd1eb44270",
-						"plaintext":     "secret",
+						sigKey:      "1b47061264138c4ac30d75fd1eb44270",
+						"plaintext": "secret",
 					},
 				},
 			},
@@ -66,14 +66,29 @@ func TestSanitizeSecretsInObject(t *testing.T) {
 			"foo": map[string]any{
 				"inner": map[string]any{
 					"secondaryAccessKey": map[string]any{
-						secretSignature: "1b47061264138c4ac30d75fd1eb44270",
-						"plaintext":     "sanitized",
+						sigKey:      "1b47061264138c4ac30d75fd1eb44270",
+						"plaintext": "sanitized",
 					},
 				},
 			},
 		}
 
 		assert.Equal(t, expected, sanitizeSecretsInObject(input, func(m map[string]any) map[string]any {
+			m["plaintext"] = "sanitized"
+			return m
+		}))
+	})
+
+	t.Run("asset unaffected", func(t *testing.T) {
+		input := map[string]any{
+			"source": map[string]any{
+				sigKey: "c44067f5952c0a294b673a41bacd8c17",
+				"hash": "678e7adc27d2686c9451d307fa0dc71ccae7a8e040c552ef1bacd453ad9e3bc9",
+				"text": "secret",
+			},
+		}
+
+		assert.Equal(t, input, sanitizeSecretsInObject(input, func(m map[string]any) map[string]any {
 			m["plaintext"] = "sanitized"
 			return m
 		}))


### PR DESCRIPTION
Secrets are identified by a specific signature value, rather than the key.

This was causing assets to be redacted incorrectly.