### PR TITLE
Update README.md to steer toward pulumitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Incubating facilities for testing Pulumi providers
 
-NOTE: The libraries in this repo are used internally by the Pulumi providers team, but are still evolving; you should expect incomplete documentation and breaking changes. If you do choose to use this library we strongly reccomend starting with [providertest/pulumitest](https://github.com/pulumi/providertest/tree/main/pulumitest) which is our latest approach. Code in this repository that is not in the pulumitest subdirectory is very likely to be deprecated and removed in the near future. 
+> [!NOTE]
+> The libraries in this repo are used internally by the Pulumi providers team, but are still evolving; you should expect incomplete documentation and breaking changes. If you do choose to use this library we strongly reccomend starting with [providertest/pulumitest](https://github.com/pulumi/providertest/tree/main/pulumitest) which is our latest approach. Code in this repository that is not in the pulumitest subdirectory is very likely to be deprecated and removed in the near future. 
 
 ## Test Modes
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Incubating facilities for testing Pulumi providers
 
-NOTE: The libraries in this repo are used internally by the Pulumi providers team, but are still evolving; you should expect incomplete documentation and breaking changes. 
+NOTE: The libraries in this repo are used internally by the Pulumi providers team, but are still evolving; you should expect incomplete documentation and breaking changes. If you do choose to use this library we strongly reccomend starting with [providertest/pulumitest](https://github.com/pulumi/providertest/tree/main/pulumitest) which is our latest approach. Code in this repository that is not in the pulumitest subdirectory is very likely to be deprecated and removed in the near future. 
 
 ## Test Modes
 


### PR DESCRIPTION
This repo is weird in that there's essentially a new and improved version in the pulumitest directory, but the older providertest code is still available in the top level (and used in some older providers tests). 

We need to clarify this in the README, so that users (internal and external) don't end up trying to write more tests that depend on providertest rather than pulumitest.