### PR TITLE
Add support for custom temp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 go.work
 
 coverage.txt
+.temp/

--- a/pulumitest/README.md
+++ b/pulumitest/README.md
@@ -15,7 +15,13 @@ func TestPulumiProgram(t *testing.T) {
 }
 ```
 
-By default your program is copied to a temporary directory before running to avoid cluttering your working directory with temporary or ephemeral files. To disable this behaviour, use `opttest.TestInPlace()`. You can also do a copy of a test manually by calling `CopyToTempDir()`:
+By default, your program is copied to a temporary directory before running to avoid modifying your source files or cluttering your working directory with temporary files. This will use an OS-specific temporary location by default but can be set to a custom directory using the `opttest.TempDir(dir)` option. Using an ignored directory within your repository can be useful for being able to locate any left-over folders retained from failed tests:
+
+```go
+test := NewPulumiTest(t, filepath.Join("path", "to", "program"), opttest.TempDir(".temp"))
+```
+
+If you don't want to copy your program to a temporary directory, use `opttest.TestInPlace()`. Also, you can also do a copy of a test manually by calling `CopyToTempDir()`:
 
 ```go
 source := NewPulumiTest(t, opttest.TestInPlace())

--- a/pulumitest/copy.go
+++ b/pulumitest/copy.go
@@ -14,7 +14,11 @@ import (
 // This is used to avoid temporary files being written to the source directory.
 func (a *PulumiTest) CopyToTempDir(t PT, opts ...opttest.Option) *PulumiTest {
 	t.Helper()
-	tempDir := tempDirWithoutCleanupOnFailedTest(t, "programDir")
+	options := a.options.Copy()
+	for _, opt := range opts {
+		opt.Apply(options)
+	}
+	tempDir := tempDirWithoutCleanupOnFailedTest(t, "programDir", options.TempDir)
 
 	// Maintain the directory name in the temp dir as this might be used for stack naming.
 	sourceBase := filepath.Base(a.workingDir)

--- a/pulumitest/newStack.go
+++ b/pulumitest/newStack.go
@@ -43,13 +43,13 @@ func (pt *PulumiTest) NewStack(t PT, stackName string, opts ...optnewstack.NewSt
 	}
 
 	if !options.UseAmbientBackend {
-		backendFolder := tempDirWithoutCleanupOnFailedTest(t, "backendDir")
+		backendFolder := tempDirWithoutCleanupOnFailedTest(t, "backendDir", options.TempDir)
 		t.Log("PULUMI_BACKEND_URL=" + "file://" + backendFolder)
 		env["PULUMI_BACKEND_URL"] = "file://" + backendFolder
 	}
 
 	if !options.DisableGrpcLog {
-		grpcLogDir := tempDirWithoutCleanupOnFailedTest(t, "grpcLogDir")
+		grpcLogDir := tempDirWithoutCleanupOnFailedTest(t, "grpcLogDir", options.TempDir)
 		t.Log("PULUMI_DEBUG_GRPC=" + filepath.Join(grpcLogDir, "grpc.json"))
 		env["PULUMI_DEBUG_GRPC"] = filepath.Join(grpcLogDir, "grpc.json")
 	}

--- a/pulumitest/opttest/opttest.go
+++ b/pulumitest/opttest/opttest.go
@@ -38,6 +38,16 @@ func TestInPlace() Option {
 	})
 }
 
+// TempDir sets the temporary directory to use when copying the program under test during an test.
+// This directory will be created if missing and will not be cleaned up after the test.
+// If not set (or set to an empty string), an OS-specific temporary directory will be used.
+// It's recommended to ignore this directory in your version control system.
+func TempDir(dir string) Option {
+	return optionFunc(func(o *Options) {
+		o.TempDir = dir
+	})
+}
+
 // AttachProvider will start the provider via the specified factory and attach it when running the program under test.
 func AttachProvider(name string, startProvider providers.ProviderFactory) Option {
 	return optionFunc(func(o *Options) {
@@ -150,6 +160,7 @@ type Options struct {
 	SkipStackCreate       bool
 	NewStackOpts          []optnewstack.NewStackOpt
 	TestInPlace           bool
+	TempDir               string
 	ConfigPassphrase      string
 	Providers             map[providers.ProviderName]ProviderConfigUnion
 	UseAmbientBackend     bool

--- a/pulumitest/pulumiTest_test.go
+++ b/pulumitest/pulumiTest_test.go
@@ -1,6 +1,7 @@
 package pulumitest
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -132,4 +133,14 @@ func TestProviderPluginPath(t *testing.T) {
 	settings, err := test.CurrentStack().Workspace().ProjectSettings(test.Context())
 	assert.NoError(t, err, "expected no error when getting project settings")
 	snaps.MatchJSON(t, settings.Plugins.Providers, match.Any("0.path"))
+}
+
+func TestCustomTempDir(t *testing.T) {
+	t.Parallel()
+	// Ensure ".temp" doesn't yet exist.
+	assert.NoError(t, os.RemoveAll(".temp"))
+	// Test installing python program in a custom local directory.
+	NewPulumiTest(t, filepath.Join("testdata", "python_gcp"), opttest.TempDir(".temp"))
+
+	assert.DirExists(t, ".temp", "should leave custom local .temp directory")
 }

--- a/pulumitest/pulumiTest_test.go
+++ b/pulumitest/pulumiTest_test.go
@@ -140,7 +140,7 @@ func TestCustomTempDir(t *testing.T) {
 	// Ensure ".temp" doesn't yet exist.
 	assert.NoError(t, os.RemoveAll(".temp"))
 	// Test installing python program in a custom local directory.
-	NewPulumiTest(t, filepath.Join("testdata", "python_gcp"), opttest.TempDir(".temp"))
+	NewPulumiTest(t, filepath.Join("testdata", "python_gcp"), opttest.TempDir(".temp/sub-dir"))
 
 	assert.DirExists(t, ".temp", "should leave custom local .temp directory")
 }

--- a/pulumitest/tempdir.go
+++ b/pulumitest/tempdir.go
@@ -20,7 +20,7 @@ func tempDirWithoutCleanupOnFailedTest(t PT, desc, tempDir string) string {
 			tempDir = absTempDir
 		}
 		if _, err := os.Stat(tempDir); os.IsNotExist(err) {
-			if err := os.Mkdir(tempDir, 0755); err != nil {
+			if err := os.MkdirAll(tempDir, 0755); err != nil {
 				ptFatalF(t, "TempDir: %v", err)
 			}
 		}

--- a/pulumitest/tempdir.go
+++ b/pulumitest/tempdir.go
@@ -3,13 +3,28 @@ package pulumitest
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"unicode"
 	"unicode/utf8"
 )
 
-func tempDirWithoutCleanupOnFailedTest(t PT, desc string) string {
+func tempDirWithoutCleanupOnFailedTest(t PT, desc, tempDir string) string {
+	if tempDir != "" { // If a tempDir is provided, create on first test and don't worry about cleanup.
+		if !filepath.IsAbs(tempDir) {
+			absTempDir, err := filepath.Abs(tempDir)
+			if err != nil {
+				ptFatalF(t, "TempDir: %v", err)
+			}
+			tempDir = absTempDir
+		}
+		if _, err := os.Stat(tempDir); os.IsNotExist(err) {
+			if err := os.Mkdir(tempDir, 0755); err != nil {
+				ptFatalF(t, "TempDir: %v", err)
+			}
+		}
+	}
 	c := getOrCreateTempDirState(t)
 
 	// Use a single parent directory for all the temporary directories
@@ -49,7 +64,7 @@ func tempDirWithoutCleanupOnFailedTest(t PT, desc string) string {
 			return -1
 		}
 		pattern := strings.Map(mapper, t.Name())
-		c.tempDir, c.tempDirErr = os.MkdirTemp("", pattern)
+		c.tempDir, c.tempDirErr = os.MkdirTemp(tempDir, pattern)
 		if c.tempDirErr == nil {
 			t.Cleanup(func() {
 				t.Helper()
@@ -78,7 +93,7 @@ func tempDirWithoutCleanupOnFailedTest(t PT, desc string) string {
 	}
 
 	dir := fmt.Sprintf("%s%c%03d", c.tempDir, os.PathSeparator, seq)
-	if err := os.Mkdir(dir, 0777); err != nil {
+	if err := os.Mkdir(dir, 0755); err != nil {
 		ptFatalF(t, "TempDir: %v", err)
 	}
 	return dir

--- a/pulumitest/testdata/python_gcp/Pulumi.yaml
+++ b/pulumitest/testdata/python_gcp/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: yaml_gcp
-runtime: python
 description: A minimal Google Cloud Pulumi YAML program
+runtime:
+  name: python
+  options:
+    toolchain: pip
+    virtualenv: venv


### PR DESCRIPTION
Make it easy to use a local temp directory for better debugging.

- Check python install process works for python (re: https://github.com/pulumi/providertest/issues/124)
- Use same 0755 permissions for all Mkdir calls.

## Readme extract

By default, your program is copied to a temporary directory before running to avoid modifying your source files or cluttering your working directory with temporary files. This will use an OS-specific temporary location by default but can be set to a custom directory using the `opttest.TempDir(dir)` option. Using an ignored directory within your repository can be useful for being able to locate any left-over folders retained from failed tests:

```go
test := NewPulumiTest(t, filepath.Join("path", "to", "program"), opttest.TempDir(".temp"))
```