### PR TITLE
Fix retention & location of temp dir via env vars

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -20,6 +20,15 @@ jobs:
 
       - name: Run acceptance tests
         run: make test
+        env:
+          PULUMITEST_TEMP_DIR: ${{ github.workspace }}/test_temp
+          PULUMITEST_RETAIN_FILES_ON_FAILURE: "true"
+
+      - name: Upload test_temp directory on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          path: test_temp
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/pulumitest/README.md
+++ b/pulumitest/README.md
@@ -149,6 +149,17 @@ Set a variable in the stack's config:
 test.SetConfig("gcp:project", "pulumi-development")
 ```
 
+## Environment Variables
+
+The behavior of pulumitest can be adjusted through use of certain environment variables:
+
+| Environment Variable | Purpose |
+|----------------------|---------|
+| `CI` | We inspect the `CI` environment flag to adjust certain defaults for an automated test environment |
+| `PULUMITEST_RETAIN_FILES` | Set to `true` to always retain temporary files. |
+| `PULUMITEST_RETAIN_FILES_ON_FAILURE` | Can be set explicitly to `true` or `false`. Defaults to `true` locally and `false` in CI environments. |
+| `PULUMITEST_SKIP_DESTROY_ON_FAILURE` | Skips the automatic attempt to destroy a stack even after a test failure. This defaults to `false`. If set to true, the files will also be retained unless `PULUMITEST_RETAIN_FILES_ON_FAILURE` set to `false`. |
+
 ## Asserts
 
 The `assertup` and `assertpreview` modules contain a selection of functions for asserting on the results of the automation API:

--- a/pulumitest/README.md
+++ b/pulumitest/README.md
@@ -15,7 +15,7 @@ func TestPulumiProgram(t *testing.T) {
 }
 ```
 
-By default, your program is copied to a temporary directory before running to avoid modifying your source files or cluttering your working directory with temporary files. This will use an OS-specific temporary location by default but can be set to a custom directory using the `opttest.TempDir(dir)` option. Using an ignored directory within your repository can be useful for being able to locate any left-over folders retained from failed tests:
+By default, your program is copied to a temporary directory before running to avoid modifying your source files or cluttering your working directory with temporary files. This will use an OS-specific temporary location by default but can be set to a custom directory using the `opttest.TempDir(dir)` option or the `PULUMITEST_TEMP_DIR` environment variable. Using an ignored directory within your repository can be useful for being able to locate any left-over folders retained from failed tests:
 
 ```go
 test := NewPulumiTest(t, filepath.Join("path", "to", "program"), opttest.TempDir(".temp"))
@@ -159,6 +159,7 @@ The behavior of pulumitest can be adjusted through use of certain environment va
 | `PULUMITEST_RETAIN_FILES` | Set to `true` to always retain temporary files. |
 | `PULUMITEST_RETAIN_FILES_ON_FAILURE` | Can be set explicitly to `true` or `false`. Defaults to `true` locally and `false` in CI environments. |
 | `PULUMITEST_SKIP_DESTROY_ON_FAILURE` | Skips the automatic attempt to destroy a stack even after a test failure. This defaults to `false`. If set to true, the files will also be retained unless `PULUMITEST_RETAIN_FILES_ON_FAILURE` set to `false`. |
+| `PULUMITEST_TEMP_DIR` | Changes the default temp directory from the OS-specific system location. |
 
 ## Asserts
 

--- a/pulumitest/cleanup.go
+++ b/pulumitest/cleanup.go
@@ -17,11 +17,24 @@ func runningInCI() bool {
 }
 
 func shouldRetainFilesOnFailure() bool {
+	if shouldAlwaysRetainFiles() {
+		return true // Always retain if retaining everything
+	}
 	if value, ok := os.LookupEnv("PULUMITEST_RETAIN_FILES_ON_FAILURE"); ok {
+		// Must be set explicitly to "false" to disable, set to anything else to enable
 		return !strings.EqualFold(value, "false")
 	}
 	if skipDestroyOnFailure() {
-		return true
+		return true // Always retain files if we're skipping destroy
 	}
-	return !runningInCI()
+	return !runningInCI() // Don't retain files by default in CI
+}
+
+// Determines whether files should always be retained, based on `PULUMITEST_RETAIN_FILES` environment variable.
+func shouldAlwaysRetainFiles() bool {
+	if value, isSet := os.LookupEnv("PULUMITEST_RETAIN_FILES"); isSet {
+		// Must be set explicitly to "true" or empty to enable. Unset or set to anything else to disable.
+		return value == "" || strings.EqualFold(value, "true")
+	}
+	return false
 }

--- a/pulumitest/opttest/opttest.go
+++ b/pulumitest/opttest/opttest.go
@@ -1,6 +1,7 @@
 package opttest
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/pulumi/providertest/providers"
@@ -203,6 +204,7 @@ func Defaults() Option {
 		o.CustomEnv = make(map[string]string)
 		o.ExtraWorkspaceOptions = []auto.LocalWorkspaceOption{}
 		o.DisableGrpcLog = false
+		o.TempDir = os.Getenv("PULUMITEST_TEMP_DIR")
 	})
 }
 

--- a/pulumitest/pulumiTest_test.go
+++ b/pulumitest/pulumiTest_test.go
@@ -1,8 +1,8 @@
 package pulumitest
 
 import (
-	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/match"
@@ -137,10 +137,12 @@ func TestProviderPluginPath(t *testing.T) {
 
 func TestCustomTempDir(t *testing.T) {
 	t.Parallel()
-	// Ensure ".temp" doesn't yet exist.
-	assert.NoError(t, os.RemoveAll(".temp"))
+	customTempDir := t.TempDir()
 	// Test installing python program in a custom local directory.
-	NewPulumiTest(t, filepath.Join("testdata", "python_gcp"), opttest.TempDir(".temp/sub-dir"))
+	test := NewPulumiTest(t, filepath.Join("testdata", "python_gcp"), opttest.TempDir(customTempDir))
 
-	assert.DirExists(t, ".temp", "should leave custom local .temp directory")
+	workingDir := test.WorkingDir()
+	if !strings.HasPrefix(workingDir, customTempDir) {
+		t.Fatalf("expected working directory to be in the custom temp directory, got %s", workingDir)
+	}
 }

--- a/pulumitest/tempdir.go
+++ b/pulumitest/tempdir.go
@@ -73,11 +73,15 @@ func tempDirWithoutCleanupOnFailedTest(t PT, desc, tempDir string) string {
 					t.Log("To remove these directories on failures, set PULUMITEST_RETAIN_FILES_ON_FAILURE=false")
 					return
 				}
-				err := os.RemoveAll(c.tempDir)
-				t.Log("Removed temp directories. To retain these, set PULUMITEST_RETAIN_FILES_ON_FAILURE=true")
-				if err != nil {
-					ptErrorF(t, "TempDir RemoveAll cleanup: %v", err)
+				if shouldAlwaysRetainFiles() {
+					ptLogF(t, "Skipping removal of %s temp directories as `PULUMITEST_RETAIN_FILES` is enabled: %q", desc, c.tempDir)
+					return
 				}
+				err := os.RemoveAll(c.tempDir)
+				if err != nil {
+					ptErrorF(t, "Failed removing %s temp directory: %q: %v", desc, c.tempDir, err)
+				}
+				t.Log("Removed temp directories. To retain these, set PULUMITEST_RETAIN_FILES=true")
 			})
 		}
 	}


### PR DESCRIPTION
## Part 1: Allow using ENV vars for temp directory control

- Add specific environment variable to always retain directories and fix instruction that didn't work for passing tests to use the new variable.
- Document environment variables in readme and document decision process for retaining directories in code comments.
- Allow setting a default temp dir via env var - this would allow it to be configured more easily in CI so that we can grab failed test directories as workflow assets.

Example config file to use this locally when running in VSCode:

```json
{
  "go.testTimeout": "320s",
  "go.testEnvVars": {
    "PULUMITEST_TEMP_DIR": "${workspaceFolder}/.tmp",
  }
}
```

## Part 2: Run with custom temp dir in CI & capture failures

This highlighted that we need to make the initial directory creation safe (added a mutex & rewrote a bad test). This also sets up an example of how to execute tests in CI and capture the temp directory on failure. 

GitHub actions example:

```yaml
      - name: Run acceptance tests
        run: go test
        env:
          PULUMITEST_TEMP_DIR: ${{ github.workspace }}/test_temp
          PULUMITEST_RETAIN_FILES_ON_FAILURE: "true"

      - name: Upload test_temp directory on failure
        if: failure()
        uses: actions/upload-artifact@v4
        with:
          path: test_temp
```

Example test run with failing test: https://github.com/pulumi/providertest/actions/runs/13902023819?pr=127

