### PR TITLE
Deprecate ProviderTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,136 +1,75 @@
-# Provider Testing
+# Pulumi Provider Testing Library
 
-Incubating facilities for testing Pulumi providers
+Library for testing Pulumi providers by running Pulumi programs.
 
 > [!NOTE]
-> The libraries in this repo are used internally by the Pulumi providers team, but are still evolving; you should expect incomplete documentation and breaking changes. If you do choose to use this library we strongly reccomend starting with [providertest/pulumitest](https://github.com/pulumi/providertest/tree/main/pulumitest) which is our latest approach. Code in this repository that is not in the pulumitest subdirectory is very likely to be deprecated and removed in the near future. 
+> The libraries in this repo are used internally by the Pulumi providers team, and are still evolving; you should expect incomplete documentation and breaking changes. If you do choose to use this library we strongly recommend starting with [providertest/pulumitest](https://github.com/pulumi/providertest/tree/main/pulumitest) which is our latest approach. The ProviderTest abstraction is deprecated and will removed in a future release.
 
-## Test Modes
+The library is composed of several modules. The most important of these is the [`pulumitest`](./pulumitest/) module. This is a library designed for testing any Pulumi program within a Go test. It extends the Go [Automation API](https://www.pulumi.com/automation/) with defaults appropriate for local testing such as using temporary directories for state.
 
-### End To End (e2e)
-
-Purpose: Prove provider behaviour for a resource is correct.
-
-This test mode does not use the SDKs, but executes the YAML program directly. There are two types of e2e test: quick and full:
-
-1. Quick will not provision real resources with the cloud provider.
-2. Full will test the whole lifecycle of resources.
-
-### SDK
-
-Purpose: Ensure parity of each supported language's SDK behaviour.
-
-SDK test are therefore split out per-language. Internally, this uses `pulumi convert` to automatically create the language-specific programs before executing them.
-
-### VerifyUpgrade
-
-Purpose: Verifies that upgrading the provider does not generate any unexpected replacements.
-
-What these tests specifically try to verify is that the provider binary release candidate under test
-will not generate any surprises for users attempting to upgrade to it from the baseline released
-version.
-
-There are currently several
-[UpgradeTestMode](https://github.com/search?q=repo%3Apulumi%2Fprovidertest+type+UpgradeTestMode&type=code)
-variations tests can run under, with different speed/accuracy trade-offs.
-
-
-## Example Usage
+Here's a short example of how to use pulumitest:
 
 ```go
-func TestSimple(t *testing.T) {
-  test := NewProviderTest("test/simple", // Point to a directory containing a Pulumi YAML program
-    WithProvider(StartLocalProvider), // Provider can be started and attached in-process
-    WithUpdateStep(UpdateStepDir("../simple-2"))) // Multi-step tests are supported
-  test.Run(t)
+import (
+  "filepath"
+  "github.com/pulumi/providertest/pulumitest"
+)
+
+func TestPulumiProgram(t *testing.T) {
+  test := NewPulumiTest(t, filepath.Join("path", "to", "program"))
+  test.Preview(t)
+  test.Up(t)
+  test.Refresh(t)
 }
 ```
 
-When calling `.Run()`, a suite of nested tests are run:
+Refer to [the full documentation](./pulumitest/README.md) for a complete walkthrough of the features.
 
-- `TestSimple/e2e`
-- `TestSimple/sdk-csharp`
-- `TestSimple/sdk-go`
-- `TestSimple/sdk-python`
-- `TestSimple/sdk-typescript`
+## Upgrade Testing
 
-If you want to run just one of these test modes directly locally, then you can temporarily replace `.Run(t)` with:
+We perform "upgrade testing" on providers to indicate when there's a change in a new version of a provider which might cause resources to be re-created during an upgrade from a previous version.
 
-```go
-test.RunE2e(t, true /*runFullTest*/)
-test.RunSdk(t, "nodejs" /*language*/)
-```
+In the root `providertest` module there is a function called `PreviewProviderUpgrade(..)`. This shows the result of a preview when upgrading from a **baseline** version of a provider to a new version of the provider. On first run it records the *baseline* state after running the program with the *baseline* version of the provider and writes it into a `testdata` directory. On subsequent runs, it restores the state from the recorded *baseline* before performing a preview operation with the new version.
 
-### Upgrade Tests
-
-Set these extra options to enable upgrade tests:
+Here's an example of how to write an upgrade test:
 
 ```go
-func TestSimple(t *testing.T) {
-  test := NewProviderTest("test/simple",
-    WithProviderName("gcp"),
-    WithBaselineVersion("6.67.0"),
-    WithResourceProviderServer(...))
-  test.Run(t)
-}
+pt := pulumitest.NewPulumiTest(t, "path-to-a-pulumi-program-dir",
+  // Use our local implementation for the new version
+  opttest.AttachProviderServer("my-provider-name", myProviderServerFactory))
+// Perform a preview of upgrading from v0.0.1 of my-provider-name to our new version.
+previewResult := providertest.PreviewProviderUpgrade(t, pt, "my-provider-name", "0.0.1")
+// Assert the preview shows no changes
+assertpreview.HasNoChanges(t, previewResult)
 ```
 
-These nested tests are added:
+It's expected that the preview operation does not perform actual network calls, though it might still require credentials to be present for the provider's `Configure` method. Where the program under test calls invokes which might fail if the original test resources no longer exist, we can intercept the invokes and replay the original responses from the gRPC messages recorded at the same time as the recorded baseline state:
 
-- `TestSimple/upgrade-snapshot`
-- `TestSimple/upgrade-preview-only`
-- `TestSimple/upgrade-quick`
-- `TestSimple/upgrade-full`
+```go
+// Turn a server factory into a *resource provider* server factory
+resourceProviderFactory := providers.ResourceProviderFactory(myProviderServerFactory)
+// Calculate the path to the baseline version recording
+upgradeCacheDir := providertest.GetUpgradeCacheDir("path-to-a-pulumi-program-dir", "5.60.0")
+// Create a new factory which will intercept and replay invokes from the recorded grpc.json
+factoryWithReplay := resourceProviderFactory.ReplayInvokes(filepath.Join(upgradeCacheDir, "grpc.json"), true)
 
-Note that `upgrade-snapshot` is a utility job rather than a test. `go test --provider-snapshot` runs
-this job to exercise the baseline version of the provider and record its behavior under `testdata`.
-The resulting recorded snapshot files are currently expected to be checked into the repo. They are
-used to inform `upgrade-quick` and `upgrade-preview-only` tests. When updating the baseline version,
-snapshots need to be recorded anew on the new version.
-
-### Fixing failing tests
-- If the tests fail by flagging unwanted resource updates or replacements that are actually
-  acceptable, configure a custom
-  [DiffValidation](https://github.com/pulumi/providertest/blob/5f23c3ec7cee882392ea356a54c0f74f56b0f7d5/upgrade.go#L241)
-  setting with more relaxed asserts.
-
-- If the tests flag legitimate upgrade issues, fixes are necessarily specific to the provider and resource being tested. 
-
-- Remember to re-record the test snapshots when making changes to the example program or the
-  baseline provider dependency.
-
-## Controlling Test Mode
-
-Which subtests are run, and in which mode (quick/full), are controlled by custom `go test` CLI flags. These can be set in makefiles or CI scripts as required.
-
-To run all sub-tests:
-
-```bash
-go test -provider-e2e -provider-sdk-all ./...
+pt := pulumitest.NewPulumiTest(t, "path-to-a-pulumi-program-dir",
+  // Use the wrapped version that will intercept invokes
+  opttest.AttachProviderServer("my-provider-name", factoryWithReplay))
 ```
 
-By default, if no modes are explicitly set, only the fast end-to-end (e2e) sub-test is executed.
+## Other Modules
 
-### Environment Variables
+The `providers` module provides additional utilities for `pulumitest` when building providers:
 
-As a temporary control method, test mode can also be enabled via the environment variable `PULUMI_PROVIDER_TEST_MODE`. Multiple options can be specified separated by commas:
+- Attaching a running provider for a specific test.
+- Starting a resource provider from within the same Go package so it can be attached and stepped through using a debugger within the test.
+- Using a specific local provider binary.
+- Downloading provider plugins at specific versions.
+- Creating a mock of a resource provider.
+- Intercepting calls to a provider via a proxy provider.
+- Replaying previously captured invoke calls from a file.
 
-```env
-PULUMI_PROVIDER_TEST_MODE=e2e,sdk-python
-```
+The `grpclog` module contains types and functions for reading, querying and writing Pulumi's grpc log format (normally living in a `grpc.json` file).
 
-> [!NOTE]
-> The environment variables should not be used in make files or CI configuration. Prefer using CLI flags for this.
-
-### Reference
-
-| Option         | CLI flag                   | Environment      | Description                                                           |
-|----------------|----------------------------|------------------|-----------------------------------------------------------------------|
-| Skip E2E       | `-provider-skip-e2e`       | `skip-e2e`       | Skip e2e provider tests                                               |
-| Full E2E       | `-provider-e2e`            | `e2e`            | Enable full e2e provider tests, otherwise uses quick mode by default. |
-| All SDK        | `-provider-sdk-all`        | `sdk-all`        | Enable all SDK tests                                                  |
-| C# SDK         | `-provider-sdk-csharp`     | `sdk-csharp`     | Enable C# SDK tests                                                   |
-| Python SDK     | `-provider-sdk-python`     | `sdk-python`     | Enable Python SDK tests                                               |
-| Go SDK         | `-provider-sdk-go`         | `sdk-go`         | Enable Go SDK tests                                                   |
-| Typescript SDK | `-provider-sdk-typescript` | `sdk-typescript` | Enable TypeScript SDK tests                                           |
-| Snapshot       | `-provider-snapshot`       | `snapshot`       | Create snapshots for use with quick e2e tests                         |
+The `replay` module has methods for exercising specific provider gRPC methods directly and from existing log files.

--- a/providertest.go
+++ b/providertest.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/providertest/flags"
 )
 
+// Deprecated: Use pulumitest.PulumiTest instead. This will be removed in a future release.
 type ProviderTest struct {
 	dir              string
 	providerStartups []StartProvider
@@ -35,6 +36,8 @@ type ProviderTest struct {
 }
 
 // NewProviderTest creates a new provider test with the initial directory to be tested.
+//
+// Deprecated: Use pulumitest.NewPulumiTest instead. This will be removed in a future release.
 func NewProviderTest(dir string, opts ...Option) *ProviderTest {
 	pt := &ProviderTest{
 		dir:     dir,

--- a/pulumitest/README.md
+++ b/pulumitest/README.md
@@ -25,7 +25,7 @@ If you don't want to copy your program to a temporary directory, use `opttest.Te
 
 ```go
 source := NewPulumiTest(t, opttest.TestInPlace())
-copy := source.CopyToTempDir()
+copy := source.CopyToTempDir(t)
 ```
 
 The `source` variable is still pointing to the original path, but the `copy` is pointing to a new PulumiTest in temporary directory which will automatically get removed at the end of the test.
@@ -40,8 +40,8 @@ The following program is equivalent to the default test setup:
 
 ```go
 test := NewPulumiTest(t, opttest.SkipInstall(), opttest.SkipStackCreate())
-test.Install() // Runs `pulumi install` to restore all dependencies
-test.NewStack("test") // Creates a new stack and returns it.
+test.Install(t) // Runs `pulumi install` to restore all dependencies
+test.NewStack(t, "test") // Creates a new stack and returns it.
 ```
 
 The `Install` and `NewStack` steps can also be done together by calling `InstallStack()`:
@@ -97,10 +97,10 @@ NewPulumiTest(t, "path", opttest.LocalProviderPath("gcp", filepath.Join("..", "b
 Preview, Up, Refresh and Destroy can be run directly from the test context:
 
 ```go
-test.Preview()
-test.Up()
-test.Refresh()
-test.Destroy()
+test.Preview(t)
+test.Up(t)
+test.Refresh(t)
+test.Destroy(t)
 ```
 
 > [!NOTE]
@@ -138,7 +138,7 @@ NewPulumiTest(t, "test_dir",
 Update source files for a subsequent step in the test:
 
 ```go
-test.UpdateSource("folder_with_updates")
+test.UpdateSource(t, "folder_with_updates")
 ```
 
 ### Set Config
@@ -146,7 +146,7 @@ test.UpdateSource("folder_with_updates")
 Set a variable in the stack's config:
 
 ```go
-test.SetConfig("gcp:project", "pulumi-development")
+test.SetConfig(t, "gcp:project", "pulumi-development")
 ```
 
 ## Environment Variables
@@ -180,25 +180,25 @@ Here's a complete example as a test might look for the gcp provider with a local
 func TestExample(t *testing.T) {
   // Copy test_dir to temp directory, install deps and create "my-stack"
   test := NewPulumiTest(t, "test_dir", opttest.AttachProviderBinary("gcp", "../bin"))
-  test.InstallStack("my-stack")
+  test.InstallStack(t, "my-stack")
 
   // Configure the test environment & project
-  test.SetConfig("gcp:project", "pulumi-development")
+  test.SetConfig(t, "gcp:project", "pulumi-development")
 
   // Preview, Deploy, Refresh, 
-  preview := test.Preview()
+  preview := test.Preview(t)
   t.Log(preview.StdOut)
 
-  deploy := test.Up()
+  deploy := test.Up(t)
   t.Log(deploy.StdOut)
-  assertpreview.HasNoChanges(t, test.Preview())
+  assertpreview.HasNoChanges(t, test.Preview(t))
 
   // Export import
-  test.ImportStack(test.ExportStack())
+  test.ImportStack(t, test.ExportStack(t))
   assertpreview.HasNoChanges(t, test.Preview())
 
   test.UpdateSource(filepath.Join("testdata", "step2"))
-  update := test.Up()
+  update := test.Up(t)
   t.Log(update.StdOut)
 }
 ```


### PR DESCRIPTION
- Add deprecation notices to root types.
- Rewrite root documentation.
- Fix some pulumitest docs examples.