### PR TITLE
Improve convert

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "go.testTimeout": "320s",
+  "go.testEnvVars": {
+    "PULUMITEST_TEMP_DIR": "${workspaceFolder}/.temp"
+  },
   "cSpell.language": "en-US",
   "cSpell.words": [
     "apitype",

--- a/pulumitest/convert.go
+++ b/pulumitest/convert.go
@@ -9,11 +9,26 @@ import (
 	"github.com/pulumi/providertest/pulumitest/opttest"
 )
 
+// ConvertResult encapsulates the result of a conversion operation.
 type ConvertResult struct {
 	// PulumiTest instance for the converted program.
 	PulumiTest *PulumiTest
 	// Combined output of the `pulumi convert` command.
 	Output string
+}
+
+// Create a new test by converting a program into a specific language.
+// It returns a new PulumiTest instance for the converted program which will be outputted into a temporary directory.
+func Convert(t PT, source, language string, opts ...opttest.Option) ConvertResult {
+	t.Helper()
+
+	pulumiTest := PulumiTest{
+		ctx:        testContext(t),
+		workingDir: source,
+		options:    opttest.DefaultOptions(),
+	}
+
+	return pulumiTest.Convert(t, language, opts...)
 }
 
 // Convert a program to a given language.

--- a/pulumitest/convert.go
+++ b/pulumitest/convert.go
@@ -21,7 +21,12 @@ type ConvertResult struct {
 func (a *PulumiTest) Convert(t PT, language string, opts ...opttest.Option) ConvertResult {
 	t.Helper()
 
-	tempDir := t.TempDir()
+	options := a.options.Copy()
+	for _, opt := range opts {
+		opt.Apply(options)
+	}
+
+	tempDir := tempDirWithoutCleanupOnFailedTest(t, "converted", options.TempDir)
 	base := filepath.Base(a.workingDir)
 	targetDir := filepath.Join(tempDir, fmt.Sprintf("%s-%s", base, language))
 	err := os.Mkdir(targetDir, 0755)
@@ -35,11 +40,6 @@ func (a *PulumiTest) Convert(t PT, language string, opts ...opttest.Option) Conv
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		ptFatalF(t, "failed to convert directory: %s\n%s", err, out)
-	}
-
-	options := a.options.Copy()
-	for _, opt := range opts {
-		opt.Apply(options)
 	}
 
 	convertedTest := &PulumiTest{

--- a/pulumitest/convert_test.go
+++ b/pulumitest/convert_test.go
@@ -1,0 +1,134 @@
+package pulumitest_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/pulumitest/assertup"
+	"github.com/pulumi/providertest/pulumitest/opttest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+)
+
+var fixedPythonRuntime = `
+runtime:
+  name: python
+  options:
+    toolchain: pip
+    virtualenv: venv
+`
+
+func TestConvertPython(t *testing.T) {
+	t.Parallel()
+
+	// No need to copy the source, since we're not going to modify it.
+	source := pulumitest.NewPulumiTest(t, filepath.Join("testdata", "yaml_program"), opttest.TestInPlace())
+
+	// Convert the original source to Python.
+	converted := source.Convert(t, "python", opttest.SkipInstall()).PulumiTest
+	assert.NotEqual(t, converted.Source(), source.Source())
+
+	// Fix up the python runtime to use venv.
+	config, err := os.ReadFile(filepath.Join(converted.WorkingDir(), "Pulumi.yaml"))
+	assert.NoError(t, err)
+	config = []byte(strings.Replace(string(config), "runtime: python", fixedPythonRuntime, 1))
+	os.WriteFile(filepath.Join(converted.WorkingDir(), "Pulumi.yaml"), config, 0644)
+
+	converted.Install(t)
+
+	pythonPreview := converted.Preview(t)
+	assert.Equal(t,
+		map[apitype.OpType]int{apitype.OpCreate: 2},
+		pythonPreview.ChangeSummary)
+
+	pythonUp := converted.Up(t)
+	assert.Equal(t,
+		map[string]int{"create": 2},
+		*pythonUp.Summary.ResourceChanges)
+
+	assertup.HasNoDeletes(t, pythonUp)
+
+	// Show the deploy output.
+	t.Log(pythonUp.StdOut)
+}
+
+func TestConvertGo(t *testing.T) {
+	t.Parallel()
+
+	// No need to copy the source, since we're not going to modify it.
+	source := pulumitest.NewPulumiTest(t, filepath.Join("testdata", "yaml_program"), opttest.TestInPlace())
+
+	// Convert the original source to Go.
+	converted := source.Convert(t, "go").PulumiTest
+	assert.NotEqual(t, converted.Source(), source.Source())
+
+	goPreview := converted.Preview(t)
+	assert.Equal(t,
+		map[apitype.OpType]int{apitype.OpCreate: 2},
+		goPreview.ChangeSummary)
+
+	goUp := converted.Up(t)
+	assert.Equal(t,
+		map[string]int{"create": 2},
+		*goUp.Summary.ResourceChanges)
+
+	assertup.HasNoDeletes(t, goUp)
+
+	// Show the deploy output.
+	t.Log(goUp.StdOut)
+}
+
+func TestConvertTypescript(t *testing.T) {
+	t.Parallel()
+
+	// No need to copy the source, since we're not going to modify it.
+	source := pulumitest.NewPulumiTest(t, filepath.Join("testdata", "yaml_program"), opttest.TestInPlace())
+
+	// Convert the original source to TypeScript.
+	converted := source.Convert(t, "typescript").PulumiTest
+	assert.NotEqual(t, converted.Source(), source.Source())
+
+	tsPreview := converted.Preview(t)
+	assert.Equal(t,
+		map[apitype.OpType]int{apitype.OpCreate: 2},
+		tsPreview.ChangeSummary)
+
+	tsUp := converted.Up(t)
+	assert.Equal(t,
+		map[string]int{"create": 2},
+		*tsUp.Summary.ResourceChanges)
+
+	assertup.HasNoDeletes(t, tsUp)
+
+	// Show the deploy output.
+	t.Log(tsUp.StdOut)
+}
+
+func TestConvertCsharp(t *testing.T) {
+	t.Parallel()
+
+	// No need to copy the source, since we're not going to modify it.
+	source := pulumitest.NewPulumiTest(t, filepath.Join("testdata", "yaml_program"), opttest.TestInPlace())
+
+	// Convert the original source to C#.
+	converted := source.Convert(t, "csharp").PulumiTest
+	assert.NotEqual(t, converted.Source(), source.Source())
+
+	csharpPreview := converted.Preview(t)
+	assert.Equal(t,
+		map[apitype.OpType]int{apitype.OpCreate: 2},
+		csharpPreview.ChangeSummary)
+
+	csharpUp := converted.Up(t)
+	assert.Equal(t,
+		map[string]int{"create": 2},
+		*csharpUp.Summary.ResourceChanges)
+
+	assertup.HasNoDeletes(t, csharpUp)
+
+	// Show the deploy output.
+	t.Log(csharpUp.StdOut)
+}

--- a/pulumitest/convert_test.go
+++ b/pulumitest/convert_test.go
@@ -21,6 +21,30 @@ runtime:
     virtualenv: venv
 `
 
+func TestImmediateConvertTypescript(t *testing.T) {
+	t.Parallel()
+
+	// No need to copy the source, since we're not going to modify it.
+	convertResult := pulumitest.Convert(t, filepath.Join("testdata", "yaml_program"), "typescript")
+	t.Log(convertResult.Output)
+	test := convertResult.PulumiTest
+
+	tsPreview := test.Preview(t)
+	assert.Equal(t,
+		map[apitype.OpType]int{apitype.OpCreate: 2},
+		tsPreview.ChangeSummary)
+
+	tsUp := test.Up(t)
+	assert.Equal(t,
+		map[string]int{"create": 2},
+		*tsUp.Summary.ResourceChanges)
+
+	assertup.HasNoDeletes(t, tsUp)
+
+	// Show the deploy output.
+	t.Log(tsUp.StdOut)
+}
+
 func TestConvertPython(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Use shared temp dir for convert rather than Go test's default location
- Expand test suite including a workaround for setting up python venv.
- Add method to construct a new test directly from a conversion result instead of having to create a test around the source YAML program, then call convert.

Extras:
- Use local temp directory for testing in VSCode.