### PR TITLE
Fail fast on provider binary missing

### DIFF
--- a/pulumitest/newStack.go
+++ b/pulumitest/newStack.go
@@ -107,6 +107,11 @@ func (pt *PulumiTest) NewStack(t PT, stackName string, opts ...optnewstack.NewSt
 			if err != nil {
 				ptFatalF(t, "failed to get absolute path for %s: %s", relPath, err)
 			}
+			_, err = os.Stat(absPath)
+			if err != nil {
+				ptFatalF(t, "failed to find binary for provider %q: %s", name, err)
+				return nil
+			}
 
 			found := false
 			for idx := range providerPlugins {

--- a/pulumitest/newStack_test.go
+++ b/pulumitest/newStack_test.go
@@ -1,0 +1,21 @@
+package pulumitest_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/pulumitest/opttest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMissingProviderBinaryPath(t *testing.T) {
+	t.Parallel()
+
+	tt := mockT{T: t}
+	pulumitest.NewPulumiTest(&tt, filepath.Join("testdata", "yaml_program"),
+		opttest.LocalProviderPath("gcp", filepath.Join("provider_directory", "file_that_does_not_exist")),
+	)
+
+	assert.True(t, tt.Failed(), "expected test to fail")
+}


### PR DESCRIPTION
New error message sample:

    /newStack_test.go:16: creating stack test
    /newStack_test.go:16: failed to find binary for provider "gcp": stat /.../provider_directory/file_that_does_not_exist: no such file or directory

Fixes #77 