### PR TITLE
Implement catch-all patterns for object keys

### DIFF
--- a/replay/json_match.go
+++ b/replay/json_match.go
@@ -121,6 +121,7 @@ func assertJSONMatchesPattern(
 				return
 			}
 			catchAllPattern, hasCatchAll := pp["*"]
+			delete(pp, "*")
 
 			// normalize escapes in pp keys
 			for k, v := range pp {
@@ -139,9 +140,6 @@ func assertJSONMatchesPattern(
 			allKeys := []string{}
 
 			for k := range pp {
-				if k == "*" {
-					continue // ignore the catch-all pattern
-				}
 				if !seenKeys[k] {
 					allKeys = append(allKeys, k)
 				}
@@ -157,7 +155,7 @@ func assertJSONMatchesPattern(
 			sort.Strings(allKeys)
 
 			for _, k := range allKeys {
-				pv, gotPV := pp[k] // pp
+				pv, gotPV := pp[k]
 				av, gotAV := aa[k]
 				subPath := fmt.Sprintf("%s[%q]", path, k)
 				switch {

--- a/replay/json_match.go
+++ b/replay/json_match.go
@@ -112,33 +112,31 @@ func match(t testingT, path string, p, a interface{}) {
 	}
 }
 
-func matchObjectPattern(t testingT, path string, expectedPattern map[string]any, actual any) {
-	pp := expectedPattern
-	a := actual
-	if esc, isEsc := detectEscape(pp); isEsc {
-		assertJSONEquals(t, path, esc, a)
+func matchObjectPattern(t testingT, path string, pattern map[string]any, value any) {
+	if esc, isEsc := detectEscape(pattern); isEsc {
+		assertJSONEquals(t, path, esc, value)
 		return
 	}
-	catchAllPattern, hasCatchAll := pp["*"]
-	delete(pp, "*")
+	catchAllPattern, hasCatchAll := pattern["*"]
+	delete(pattern, "*")
 
 	// normalize escapes in pp keys
-	for k, v := range pp {
-		delete(pp, k)
+	for k, v := range pattern {
+		delete(pattern, k)
 		k = strings.TrimPrefix(k, "\\")
-		pp[k] = v
+		pattern[k] = v
 	}
 
-	aa, ok := a.(map[string]interface{})
+	aa, ok := value.(map[string]interface{})
 	if !ok {
-		t.Errorf("[%s]: expected an object, but got %s", path, prettyJSON(t, a))
+		t.Errorf("[%s]: expected an object, but got %s", path, prettyJSON(t, value))
 		return
 	}
 
 	seenKeys := map[string]bool{}
 	allKeys := []string{}
 
-	for k := range pp {
+	for k := range pattern {
 		if !seenKeys[k] {
 			allKeys = append(allKeys, k)
 		}
@@ -154,7 +152,7 @@ func matchObjectPattern(t testingT, path string, expectedPattern map[string]any,
 	sort.Strings(allKeys)
 
 	for _, k := range allKeys {
-		pv, gotPV := pp[k]
+		pv, gotPV := pattern[k]
 		av, gotAV := aa[k]
 		subPath := fmt.Sprintf("%s[%q]", path, k)
 		switch {

--- a/replay/json_match.go
+++ b/replay/json_match.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -119,6 +120,14 @@ func assertJSONMatchesPattern(
 				assertJSONEquals(t, path, esc, a)
 				return
 			}
+			catchAllPattern, hasCatchAll := pp["*"]
+
+			// normalize escapes in pp keys
+			for k, v := range pp {
+				delete(pp, k)
+				k = strings.TrimPrefix(k, "\\")
+				pp[k] = v
+			}
 
 			aa, ok := a.(map[string]interface{})
 			if !ok {
@@ -147,10 +156,8 @@ func assertJSONMatchesPattern(
 			}
 			sort.Strings(allKeys)
 
-			catchAllPattern, hasCatchAll := pp["*"]
-
 			for _, k := range allKeys {
-				pv, gotPV := pp[k]
+				pv, gotPV := pp[k] // pp
 				av, gotAV := aa[k]
 				subPath := fmt.Sprintf("%s[%q]", path, k)
 				switch {

--- a/replay/json_match_test.go
+++ b/replay/json_match_test.go
@@ -80,6 +80,16 @@ func TestKeyEscapes(t *testing.T) {
 	require.Contains(t, mt.errors[0], `unexpected value "_"`)
 }
 
+func TestObjectPatternConflict(t *testing.T) {
+	mt := &mockTestingT{}
+	assertJSONMatchesPattern(mt,
+		[]byte(`{"\\foo": "1", "foo": "2"}`),
+		[]byte(`{}`))
+	require.NotEmpty(t, mt.errors)
+	require.Equal(t, 1, len(mt.errors))
+	require.Contains(t, mt.errors[0], `object key pattern "foo" specified more than once`)
+}
+
 type mockTestingT struct {
 	errors []string
 }

--- a/replay/json_match_test.go
+++ b/replay/json_match_test.go
@@ -75,6 +75,9 @@ func TestKeyEscapes(t *testing.T) {
 		[]byte(`{"\\*": "*"}`),
 		[]byte(`{"*": "ok", "extra": "_"}`))
 	require.NotEmpty(t, mt.errors)
+	require.Equal(t, 1, len(mt.errors))
+	require.Contains(t, mt.errors[0], `#["extra"]`)
+	require.Contains(t, mt.errors[0], `unexpected value "_"`)
 }
 
 type mockTestingT struct {

--- a/replay/json_match_test.go
+++ b/replay/json_match_test.go
@@ -63,6 +63,20 @@ func TestCatchAllPattern(t *testing.T) {
 	})
 }
 
+func TestKeyEscapes(t *testing.T) {
+	t.Parallel()
+
+	assertJSONMatchesPattern(t,
+		[]byte(`{"\\foo": "bar"}`),
+		[]byte(`{"foo": "bar"}`))
+
+	mt := &mockTestingT{}
+	assertJSONMatchesPattern(mt,
+		[]byte(`{"\\*": "*"}`),
+		[]byte(`{"*": "ok", "extra": "_"}`))
+	require.NotEmpty(t, mt.errors)
+}
+
 type mockTestingT struct {
 	errors []string
 }

--- a/replay/json_match_test.go
+++ b/replay/json_match_test.go
@@ -39,6 +39,30 @@ func TestJsonListLengthMistmatch(t *testing.T) {
 	require.Equal(t, "[#]: expected an array of length 2, but got [\n  1,\n  2,\n  3\n]", mt.errors[0])
 }
 
+func TestCatchAllPattern(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Accept extraneous keys", func(t *testing.T) {
+		t.Parallel()
+
+		assertJSONMatchesPattern(t,
+			[]byte(`{"foo": "bar", "*": "*"}`),
+			[]byte(`{"foo": "bar", "baz": 1}`))
+	})
+
+	t.Run("Reject extraneous keys that do not match", func(t *testing.T) {
+		t.Parallel()
+
+		mt := &mockTestingT{}
+		assertJSONMatchesPattern(mt,
+			[]byte(`{"foo": "bar", "*": "2"}`),
+			[]byte(`{"foo": "bar", "baz": 1, "x": "2"}`))
+		require.NotEmpty(t, mt.errors)
+		require.Equal(t, 1, len(mt.errors))
+		require.Contains(t, mt.errors[0], `#["baz"]`)
+	})
+}
+
 type mockTestingT struct {
 	errors []string
 }


### PR DESCRIPTION
Replay tests while discouraged are still in use; one particular aspect where they are brittle is that they do not tolerate added new keys. This change makes the pattern language more powerful to specify catch-all patterns for object values for keys not matched by any other key pattern, and as a special case of this, ignoring any such keys.

Use case is tolerating e.g. pulumi-random test failures such as:

```
=== RUN   TestRegress160
    json_match.go:150: [#["properties"]["__pulumi_raw_state_delta"]] unexpected value {
          "obj": {}
        }
```