### PR TITLE
Respect PULUMI_HOME

### DIFF
--- a/providers/downloadPluginBinary.go
+++ b/providers/downloadPluginBinary.go
@@ -28,12 +28,12 @@ func DownloadPluginBinary(name, version string) (string, error) {
 		return "", fmt.Errorf("failed to install plugin: %s\n%s", err, out)
 	}
 
-	pulumiHome, err := workspace.GetPulumiHomeDir()
+	pluginDir, err := workspace.GetPluginDir()
 	if err != nil {
-		return "", fmt.Errorf("failed to get pulumi home dir: %v", err)
+		return "", fmt.Errorf("failed to get plugin dir: %v", err)
 	}
 
-	binaryPath := filepath.Join(pulumiHome, "plugins", fmt.Sprintf("resource-%s-v%s", name, version))
+	binaryPath := filepath.Join(pluginDir, fmt.Sprintf("resource-%s-v%s", name, version))
 	if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
 		return "", fmt.Errorf("expected plugin binary to exist at %s", binaryPath)
 	}

--- a/providers/downloadPluginBinary.go
+++ b/providers/downloadPluginBinary.go
@@ -26,11 +26,16 @@ func DownloadPluginBinary(name, version string) (string, error) {
 		return "", fmt.Errorf("failed to install plugin: %s\n%s", err, out)
 	}
 
-	userHomeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("failed to get user home dir: %v", err)
+	pulumiHome := os.Getenv("PULUMI_HOME")
+	if pulumiHome == "" {
+		userHomeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get user home dir: %v", err)
+		}
+		pulumiHome = filepath.Join(userHomeDir, ".pulumi")
 	}
-	binaryPath := filepath.Join(userHomeDir, ".pulumi", "plugins", fmt.Sprintf("resource-%s-v%s", name, version))
+
+	binaryPath := filepath.Join(pulumiHome, "plugins", fmt.Sprintf("resource-%s-v%s", name, version))
 	if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
 		return "", fmt.Errorf("expected plugin binary to exist at %s", binaryPath)
 	}

--- a/providers/downloadPluginBinary.go
+++ b/providers/downloadPluginBinary.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 func DownloadPluginBinaryFactory(name, version string) ProviderFactory {
@@ -26,13 +28,9 @@ func DownloadPluginBinary(name, version string) (string, error) {
 		return "", fmt.Errorf("failed to install plugin: %s\n%s", err, out)
 	}
 
-	pulumiHome := os.Getenv("PULUMI_HOME")
-	if pulumiHome == "" {
-		userHomeDir, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("failed to get user home dir: %v", err)
-		}
-		pulumiHome = filepath.Join(userHomeDir, ".pulumi")
+	pulumiHome, err := workspace.GetPulumiHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get pulumi home dir: %v", err)
 	}
 
 	binaryPath := filepath.Join(pulumiHome, "plugins", fmt.Sprintf("resource-%s-v%s", name, version))


### PR DESCRIPTION
providertest currently assumes all plugins are installed to `~/.pulumi/plugins` but a test might run under a different `PULUMI_HOME` and we should respect that.

This unblocks docker-build workflows currently failing with:
```
--- FAIL: TestNodeExampleUpgrade (1.54s)
panic: expected plugin binary to exist at /home/runner/.pulumi/plugins/resource-docker-build-v0.0.7 [recovered]
	panic: expected plugin binary to exist at /home/runner/.pulumi/plugins/resource-docker-build-v0.0.7
```