### PR TITLE
fix: PythonLink now works without SkipInstall by bypassing pulumi ins…

### DIFF
--- a/pulumitest/README.md
+++ b/pulumitest/README.md
@@ -161,7 +161,16 @@ test := NewPulumiTest(t,
 
 ### Python - Local Package Installation
 
-For Python, we support installing local packages in editable mode via `pip install -e`. This allows using a local build of the Python SDK during testing. Before running your test, ensure your Python environment is properly configured (typically within a virtual environment).
+For Python, we support installing local packages in editable mode via `pip install -e`. This allows using a local build of the Python SDK during testing.
+
+**How it works:**
+When `PythonLink` is specified, the test framework handles Python dependency installation itself instead of using `pulumi install`. This avoids PEP 668 issues on systems with externally-managed Python.
+
+1. Creates a virtual environment at `venv` in the test directory
+2. Upgrades pip, setuptools, and wheel in the venv
+3. Installs local packages via `pip install -e` (PythonLinks)
+4. Installs requirements.txt dependencies
+5. Runs `pulumi plugin install` for Pulumi provider plugins
 
 The local package installation can be specified using the `PythonLink` test option:
 
@@ -175,6 +184,20 @@ Multiple packages can be specified:
 NewPulumiTest(t, "test_dir",
   opttest.PythonLink("../sdk/python", "../other-sdk/python"))
 ```
+
+**Note:** You do NOT need to use `SkipInstall()` with PythonLink. The framework automatically handles Python installation, bypassing `pulumi install` to avoid PEP 668 issues.
+
+**Pulumi.yaml Configuration:** Your Python project's `Pulumi.yaml` must specify the virtualenv location so Pulumi knows where to find the virtual environment that PythonLink creates:
+
+```yaml
+runtime:
+  name: python
+  options:
+    toolchain: pip
+    virtualenv: venv
+```
+
+If the `virtualenv` option is missing, the framework will display a helpful error message explaining exactly what needs to be added to your `Pulumi.yaml` file.
 
 ## Additional Operations
 

--- a/pulumitest/newStack.go
+++ b/pulumitest/newStack.go
@@ -162,28 +162,10 @@ func (pt *PulumiTest) NewStack(t PT, stackName string, opts ...optnewstack.NewSt
 		}
 	}
 
-	if len(options.PythonLinks) > 0 {
-		// Determine which Python interpreter to use. Try python3 first for better
-		// compatibility with modern systems, then fall back to python.
-		pythonCmd := "python"
-		if _, err := exec.LookPath("python3"); err == nil {
-			pythonCmd = "python3"
-		}
-
-		for _, pkgPath := range options.PythonLinks {
-			absPath, err := filepath.Abs(pkgPath)
-			if err != nil {
-				ptFatalF(t, "failed to get absolute path for %s: %s", pkgPath, err)
-			}
-			cmd := exec.Command(pythonCmd, "-m", "pip", "install", "-e", absPath)
-			cmd.Dir = pt.workingDir
-			ptLogF(t, "installing python package: %s", cmd)
-			out, err := cmd.CombinedOutput()
-			if err != nil {
-				ptFatalF(t, "failed to install python package %s: %s\n%s", pkgPath, err, out)
-			}
-		}
-	}
+	// NOTE: PythonLinks are handled in pulumiTestInit() via installPythonDependencies().
+	// When PythonLinks are specified, the framework bypasses `pulumi install` entirely
+	// and handles Python venv creation, package installation, and requirements.txt
+	// installation itself to avoid PEP 668 issues.
 
 	if len(options.GoModReplacements) > 0 {
 		orderedReplacements := make([]string, 0, len(options.GoModReplacements))

--- a/pulumitest/pulumiTest.go
+++ b/pulumitest/pulumiTest.go
@@ -2,9 +2,14 @@ package pulumitest
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 
 	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
+	"gopkg.in/yaml.v3"
 )
 
 type PulumiTest struct {
@@ -56,7 +61,14 @@ func testContext(t PT) context.Context {
 func pulumiTestInit(t PT, pt *PulumiTest, options *opttest.Options) {
 	t.Helper()
 	if !options.SkipInstall {
-		pt.Install(t)
+		// When PythonLinks are specified, we handle Python installation ourselves
+		// instead of relying on `pulumi install`. This is because `pulumi install`
+		// may fail on systems with PEP 668 restrictions (externally-managed Python).
+		if len(options.PythonLinks) > 0 {
+			pt.installPythonDependencies(t, options.PythonLinks)
+		} else {
+			pt.Install(t)
+		}
 	}
 	if !options.SkipStackCreate {
 		pt.NewStack(t, options.StackName, options.NewStackOpts...)
@@ -82,4 +94,220 @@ func (pt *PulumiTest) Context() context.Context {
 // CurrentStack returns the last stack that was created or nil if no stack has been created yet.
 func (pt *PulumiTest) CurrentStack() *auto.Stack {
 	return pt.currentStack
+}
+
+// pulumiYAMLRuntime represents the runtime section of Pulumi.yaml for validation
+type pulumiYAMLRuntime struct {
+	Name    string `yaml:"name"`
+	Options struct {
+		Virtualenv string `yaml:"virtualenv"`
+		Toolchain  string `yaml:"toolchain"`
+	} `yaml:"options"`
+}
+
+// pulumiYAML represents the minimal Pulumi.yaml structure needed for validation
+type pulumiYAML struct {
+	Runtime interface{} `yaml:"runtime"`
+}
+
+// validatePythonRuntimeConfig checks that Pulumi.yaml has the required runtime configuration
+// for PythonLink to work correctly. Returns an error with helpful instructions if misconfigured.
+func validatePythonRuntimeConfig(workingDir string) error {
+	pulumiYamlPath := filepath.Join(workingDir, "Pulumi.yaml")
+	data, err := os.ReadFile(pulumiYamlPath)
+	if err != nil {
+		return fmt.Errorf("failed to read Pulumi.yaml: %w", err)
+	}
+
+	var config pulumiYAML
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return fmt.Errorf("failed to parse Pulumi.yaml: %w", err)
+	}
+
+	// Handle both string ("python") and object runtime configurations
+	var runtimeConfig pulumiYAMLRuntime
+	switch rt := config.Runtime.(type) {
+	case string:
+		// Simple format: "runtime: python" - missing required options
+		if rt == "python" {
+			return fmt.Errorf(`PythonLink requires Pulumi.yaml to specify the virtualenv location
+
+Your Pulumi.yaml has:
+  runtime: python
+
+Please update it to:
+  runtime:
+    name: python
+    options:
+      toolchain: pip
+      virtualenv: venv
+
+This tells Pulumi to use the venv directory that PythonLink creates`)
+		}
+		return nil // Not a Python project
+	case map[string]interface{}:
+		// Object format - need to re-parse to get the full structure
+		runtimeBytes, _ := yaml.Marshal(rt)
+		if err := yaml.Unmarshal(runtimeBytes, &runtimeConfig); err != nil {
+			return fmt.Errorf("failed to parse runtime config: %w", err)
+		}
+	default:
+		return nil // Unknown format, let Pulumi handle it
+	}
+
+	// Check if it's a Python project
+	if runtimeConfig.Name != "python" {
+		return nil // Not a Python project
+	}
+
+	// Check for virtualenv configuration
+	if runtimeConfig.Options.Virtualenv == "" {
+		return fmt.Errorf(`PythonLink requires Pulumi.yaml to specify the virtualenv location
+
+Your Pulumi.yaml has:
+  runtime:
+    name: python
+
+Please add the virtualenv option:
+  runtime:
+    name: python
+    options:
+      toolchain: pip
+      virtualenv: venv
+
+This tells Pulumi to use the venv directory that PythonLink creates`)
+	}
+
+	return nil
+}
+
+// getPythonVenvPath returns the virtualenv path configured in Pulumi.yaml, or "venv" as default.
+func getPythonVenvPath(workingDir string) string {
+	pulumiYamlPath := filepath.Join(workingDir, "Pulumi.yaml")
+	data, err := os.ReadFile(pulumiYamlPath)
+	if err != nil {
+		return "venv" // Default
+	}
+
+	var config pulumiYAML
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return "venv" // Default
+	}
+
+	switch rt := config.Runtime.(type) {
+	case map[string]interface{}:
+		runtimeBytes, _ := yaml.Marshal(rt)
+		var runtimeConfig pulumiYAMLRuntime
+		if err := yaml.Unmarshal(runtimeBytes, &runtimeConfig); err == nil {
+			if runtimeConfig.Options.Virtualenv != "" {
+				return runtimeConfig.Options.Virtualenv
+			}
+		}
+	}
+
+	return "venv" // Default
+}
+
+// installPythonDependencies handles the complete Python dependency installation when
+// PythonLinks are specified. This bypasses `pulumi install` entirely for Python projects
+// to avoid PEP 668 issues where `pulumi install` tries to use system Python.
+//
+// The function:
+// 1. Validates Pulumi.yaml has required runtime configuration
+// 2. Creates a virtual environment at venv/
+// 3. Upgrades pip in the venv
+// 4. Installs local packages via pip install -e (PythonLinks)
+// 5. Installs requirements.txt dependencies
+// 6. Runs `pulumi plugin install` for Pulumi provider plugins
+func (pt *PulumiTest) installPythonDependencies(t PT, pythonLinks []string) {
+	t.Helper()
+
+	// Validate Pulumi.yaml has required configuration
+	if err := validatePythonRuntimeConfig(pt.workingDir); err != nil {
+		ptFatalF(t, "%s", err)
+	}
+
+	ptLogF(t, "installing Python dependencies (bypassing pulumi install)")
+
+	// Determine which Python interpreter to use. Try python3 first for better
+	// compatibility with modern systems, then fall back to python.
+	pythonCmd := "python"
+	if _, err := exec.LookPath("python3"); err == nil {
+		pythonCmd = "python3"
+	}
+
+	// Get the virtualenv path from Pulumi.yaml configuration
+	venvDir := getPythonVenvPath(pt.workingDir)
+	venvPath := filepath.Join(pt.workingDir, venvDir)
+
+	// Step 1: Create venv if it doesn't exist
+	if _, err := os.Stat(venvPath); os.IsNotExist(err) {
+		cmd := exec.Command(pythonCmd, "-m", "venv", venvPath)
+		cmd.Dir = pt.workingDir
+		ptLogF(t, "creating virtual environment: %s", cmd)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			ptFatalF(t, "failed to create virtual environment: %s\n%s", err, out)
+		}
+	}
+
+	// Determine the pip and python paths inside the venv (platform-specific)
+	var pipPath, venvPython string
+	if _, err := os.Stat(filepath.Join(venvPath, "Scripts", "pip.exe")); err == nil {
+		// Windows
+		pipPath = filepath.Join(venvPath, "Scripts", "pip.exe")
+		venvPython = filepath.Join(venvPath, "Scripts", "python.exe")
+	} else {
+		// Unix-like
+		pipPath = filepath.Join(venvPath, "bin", "pip")
+		venvPython = filepath.Join(venvPath, "bin", "python")
+	}
+
+	// Step 2: Upgrade pip in the venv (using venv's Python, not system Python)
+	cmd := exec.Command(venvPython, "-m", "pip", "install", "--upgrade", "pip", "setuptools", "wheel")
+	cmd.Dir = pt.workingDir
+	ptLogF(t, "upgrading pip in venv: %s", cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		ptLogF(t, "warning: failed to upgrade pip (continuing anyway): %s\n%s", err, out)
+		// Don't fail here - pip upgrade is nice-to-have but not required
+	}
+
+	// Step 3: Install local packages (PythonLinks) via editable install
+	for _, pkgPath := range pythonLinks {
+		absPath, err := filepath.Abs(pkgPath)
+		if err != nil {
+			ptFatalF(t, "failed to get absolute path for %s: %s", pkgPath, err)
+		}
+		cmd := exec.Command(pipPath, "install", "-e", absPath)
+		cmd.Dir = pt.workingDir
+		ptLogF(t, "installing local python package: %s", cmd)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			ptFatalF(t, "failed to install python package %s: %s\n%s", pkgPath, err, out)
+		}
+	}
+
+	// Step 4: Install requirements.txt if it exists
+	requirementsPath := filepath.Join(pt.workingDir, "requirements.txt")
+	if _, err := os.Stat(requirementsPath); err == nil {
+		cmd := exec.Command(pipPath, "install", "-r", requirementsPath)
+		cmd.Dir = pt.workingDir
+		ptLogF(t, "installing requirements.txt: %s", cmd)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			ptFatalF(t, "failed to install requirements.txt: %s\n%s", err, out)
+		}
+	}
+
+	// Step 5: Install Pulumi plugins
+	cmd = exec.Command("pulumi", "plugin", "install")
+	cmd.Dir = pt.workingDir
+	ptLogF(t, "installing Pulumi plugins: %s", cmd)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		// Plugin install failure is often not fatal - the plugins may be
+		// already installed or not needed for the test
+		ptLogF(t, "warning: pulumi plugin install had issues: %s\n%s", err, out)
+	}
 }

--- a/pulumitest/testdata/python_with_local_pkg/Pulumi.yaml
+++ b/pulumitest/testdata/python_with_local_pkg/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: python-with-local-pkg
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: pip
+    virtualenv: venv
 description: Test program for PythonLink integration tests

--- a/pulumitest/testdata/python_with_local_pkg/requirements.txt
+++ b/pulumitest/testdata/python_with_local_pkg/requirements.txt
@@ -1,1 +1,6 @@
-# This is intentionally empty - we'll use PythonLink to install the local package
+# Pulumi SDK is required for all Pulumi programs
+pulumi>=3.0.0
+
+# This package doesn't exist on PyPI - it must be installed via PythonLink
+# before `pulumi install` runs, otherwise pip will fail.
+pulumi-test-pkg>=0.0.1


### PR DESCRIPTION
…tall

When PythonLinks are specified, the framework now handles Python dependency installation itself instead of relying on `pulumi install`. This avoids PEP 668 issues on systems with externally-managed Python.

The new flow:
1. Creates a venv at `venv/` (Pulumi's default location)
2. Upgrades pip using the venv's Python (not system Python)
3. Installs local packages via `pip install -e`
4. Installs requirements.txt dependencies
5. Runs `pulumi plugin install` for Pulumi plugins

Users must configure their Pulumi.yaml with:
  runtime:
    name: python
    options:
      toolchain: pip
      virtualenv: venv

Fixes the issue where PythonLink required SkipInstall() to work.