### PR TITLE
Fix python_gcp test by adding setuptools dependency

### DIFF
--- a/pulumitest/testdata/python_gcp/requirements.txt
+++ b/pulumitest/testdata/python_gcp/requirements.txt
@@ -1,2 +1,3 @@
 pulumi>=3.0.0,<4.0.0
 pulumi-gcp==7.6.0
+setuptools<81  # Required by pulumi-gcp 7.6.0 for pkg_resources (removed in v81+)


### PR DESCRIPTION
## Summary

Fixes the `TestProviderMock/with_mocks` test failure by pinning `setuptools<81` in the `python_gcp` test requirements.

## Root Cause

The test started failing on Feb 10, 2026 due to a combination of two changes:

1. **Feb 8, 2026**: setuptools 81.0.0 was released, which **completely removed** `pkg_resources`
2. **Feb 9, 2026**: GitHub Actions updated pip to version 26.0.1

When `pulumi install` creates a virtual environment and installs dependencies, it installs the latest setuptools by default. Since setuptools 81+ no longer includes `pkg_resources`, the import fails even though setuptools itself is installed.

- pulumi-gcp 7.6.0 depends on `pkg_resources` (from setuptools) in its `_utilities.py` file
- setuptools 82.0.0 (latest) does not include `pkg_resources` - it was removed in v81+
- This caused: `ModuleNotFoundError: No module named 'pkg_resources'`

## Solution

Added `setuptools<81` to `providertest/pulumitest/testdata/python_gcp/requirements.txt` to ensure a version with `pkg_resources` is installed.

## Investigation Notes

Initial attempt added `setuptools` without a version constraint, which installed v82.0.0 and still failed. Analysis of the test artifacts revealed that setuptools was installed but `pkg_resources` was missing, leading to the discovery that setuptools 81+ removed it entirely.

## Test Plan

- [x] Verify acceptance tests pass with this change
- [x] Confirm TestProviderMock/with_mocks no longer fails

Fixes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)