### PR TITLE
feat(pulumitest): log pulumi version and plugins on stack creation

### DIFF
--- a/pulumitest/newStack.go
+++ b/pulumitest/newStack.go
@@ -254,6 +254,9 @@ func (pt *PulumiTest) NewStack(t PT, stackName string, opts ...optnewstack.NewSt
 		})
 	}
 	pt.currentStack = &stack
+	if !options.DisablePulumiVersionLog {
+		pt.logPulumiVersionInfo(t)
+	}
 	return &stack
 }
 

--- a/pulumitest/opttest/opttest.go
+++ b/pulumitest/opttest/opttest.go
@@ -152,6 +152,14 @@ func DisableGrpcLog() Option {
 	})
 }
 
+// DisablePulumiVersionLog disables logging the Pulumi CLI version and project plugin list when a stack is created.
+// By default, NewStack runs `pulumi version` and `pulumi plugin ls -p` and writes their output to the test log to aid debugging.
+func DisablePulumiVersionLog() Option {
+	return optionFunc(func(o *Options) {
+		o.DisablePulumiVersionLog = true
+	})
+}
+
 // Set a custom environment variable to use when running the program under test.
 func Env(key, value string) Option {
 	return optionFunc(func(o *Options) {
@@ -180,23 +188,24 @@ func NewStackOptions(opts ...optnewstack.NewStackOpt) Option {
 }
 
 type Options struct {
-	StackName             string
-	SkipInstall           bool
-	SkipStackCreate       bool
-	NewStackOpts          []optnewstack.NewStackOpt
-	TestInPlace           bool
-	TempDir               string
-	ConfigPassphrase      string
-	Providers             map[providers.ProviderName]ProviderConfigUnion
-	UseAmbientBackend     bool
-	YarnLinks             []string
-	PythonLinks           []string
-	RequireYarnLinks      *bool
-	GoModReplacements     map[string]string
-	DotNetReferences      map[string]string
-	CustomEnv             map[string]string
-	ExtraWorkspaceOptions []auto.LocalWorkspaceOption
-	DisableGrpcLog        bool
+	StackName               string
+	SkipInstall             bool
+	SkipStackCreate         bool
+	NewStackOpts            []optnewstack.NewStackOpt
+	TestInPlace             bool
+	TempDir                 string
+	ConfigPassphrase        string
+	Providers               map[providers.ProviderName]ProviderConfigUnion
+	UseAmbientBackend       bool
+	YarnLinks               []string
+	PythonLinks             []string
+	RequireYarnLinks        *bool
+	GoModReplacements       map[string]string
+	DotNetReferences        map[string]string
+	CustomEnv               map[string]string
+	ExtraWorkspaceOptions   []auto.LocalWorkspaceOption
+	DisableGrpcLog          bool
+	DisablePulumiVersionLog bool
 }
 
 // ProviderConfigUnion is a union type for specifying a provider configuration.
@@ -234,6 +243,7 @@ func Defaults() Option {
 		o.CustomEnv = make(map[string]string)
 		o.ExtraWorkspaceOptions = []auto.LocalWorkspaceOption{}
 		o.DisableGrpcLog = false
+		o.DisablePulumiVersionLog = false
 		o.TempDir = os.Getenv("PULUMITEST_TEMP_DIR")
 	})
 }

--- a/pulumitest/opttest/opttest_test.go
+++ b/pulumitest/opttest/opttest_test.go
@@ -104,6 +104,29 @@ func TestPythonLinkIntegrationV2(t *testing.T) {
 	assert.True(t, len(opts.PythonLinks[0]) > 0, "expected non-empty package path")
 }
 
+func TestDisablePulumiVersionLogOption(t *testing.T) {
+	t.Parallel()
+
+	opts := opttest.DefaultOptions()
+	assert.False(t, opts.DisablePulumiVersionLog, "expected DisablePulumiVersionLog to be false by default")
+
+	opttest.DisablePulumiVersionLog().Apply(opts)
+
+	assert.True(t, opts.DisablePulumiVersionLog, "expected DisablePulumiVersionLog() to set the flag to true")
+}
+
+func TestDefaultsResetsDisablePulumiVersionLog(t *testing.T) {
+	t.Parallel()
+
+	opts := opttest.DefaultOptions()
+	opttest.DisablePulumiVersionLog().Apply(opts)
+	assert.True(t, opts.DisablePulumiVersionLog, "expected DisablePulumiVersionLog to be true before Defaults()")
+
+	opttest.Defaults().Apply(opts)
+
+	assert.False(t, opts.DisablePulumiVersionLog, "expected Defaults() to reset DisablePulumiVersionLog to false")
+}
+
 func TestPythonLinkUpgradePathGeneration(t *testing.T) {
 	t.Parallel()
 

--- a/pulumitest/versionLog.go
+++ b/pulumitest/versionLog.go
@@ -1,0 +1,41 @@
+package pulumitest
+
+import (
+	"fmt"
+	"strings"
+)
+
+func formatCommandDiagnostics(stdout, stderr string) string {
+	parts := make([]string, 0, 2)
+	if trimmed := strings.TrimSpace(stdout); trimmed != "" {
+		parts = append(parts, "stdout: "+trimmed)
+	}
+	if trimmed := strings.TrimSpace(stderr); trimmed != "" {
+		parts = append(parts, "stderr: "+trimmed)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(parts, "; ") + ")"
+}
+
+func (pt *PulumiTest) logPulumiVersionInfo(t PT) {
+	t.Helper()
+	workspace := pt.currentStack.Workspace()
+	cmd := workspace.PulumiCommand()
+	workdir := workspace.WorkDir()
+	env := make([]string, 0, len(workspace.GetEnvVars()))
+	for k, v := range workspace.GetEnvVars() {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+	if stdout, stderr, _, err := cmd.Run(pt.ctx, workdir, nil, nil, nil, env, "version"); err != nil {
+		ptLogF(t, "failed to get pulumi version: %v%s", err, formatCommandDiagnostics(stdout, stderr))
+	} else {
+		ptLogF(t, "pulumi version: %s", strings.TrimSpace(stdout))
+	}
+	if stdout, stderr, _, err := cmd.Run(pt.ctx, workdir, nil, nil, nil, env, "plugin", "ls", "-p"); err != nil {
+		ptLogF(t, "failed to list pulumi plugins: %v%s", err, formatCommandDiagnostics(stdout, stderr))
+	} else {
+		ptLogF(t, "pulumi plugins:\n%s", strings.TrimSpace(stdout))
+	}
+}

--- a/pulumitest/versionLog_test.go
+++ b/pulumitest/versionLog_test.go
@@ -1,0 +1,63 @@
+package pulumitest_test
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/pulumitest/opttest"
+	"github.com/stretchr/testify/assert"
+)
+
+type logCaptureT struct {
+	*testing.T
+	mu   sync.Mutex
+	logs []string
+}
+
+func (t *logCaptureT) Log(args ...any) {
+	line := fmt.Sprint(args...)
+	t.mu.Lock()
+	t.logs = append(t.logs, line)
+	t.mu.Unlock()
+	t.T.Log(args...)
+}
+
+func (t *logCaptureT) logged(substr string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, line := range t.logs {
+		if strings.Contains(line, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestLogsPulumiVersionOnStackCreation(t *testing.T) {
+	t.Parallel()
+	ct := &logCaptureT{T: t}
+
+	pulumitest.NewPulumiTest(ct, "testdata/yaml_program")
+
+	assert.True(t,
+		ct.logged("pulumi version:") || ct.logged("failed to get pulumi version"),
+		"expected pulumi version success or failure to be logged")
+	assert.True(t,
+		ct.logged("pulumi plugins:") || ct.logged("failed to list pulumi plugins"),
+		"expected pulumi plugins success or failure to be logged")
+}
+
+func TestDisablePulumiVersionLogSuppressesOutput(t *testing.T) {
+	t.Parallel()
+	ct := &logCaptureT{T: t}
+
+	pulumitest.NewPulumiTest(ct, "testdata/yaml_program", opttest.DisablePulumiVersionLog())
+
+	assert.False(t, ct.logged("pulumi version:"), "expected pulumi version log to be suppressed")
+	assert.False(t, ct.logged("pulumi plugins:"), "expected pulumi plugins log to be suppressed")
+	assert.False(t, ct.logged("failed to get pulumi version"), "expected pulumi version failure log to be suppressed")
+	assert.False(t, ct.logged("failed to list pulumi plugins"), "expected pulumi plugins failure log to be suppressed")
+}


### PR DESCRIPTION
## Summary

- Emits `pulumi version` and `pulumi plugin ls -p` output to the test log whenever a stack is created, so failing tests surface the CLI and plugin versions without re-running with extra instrumentation
- Behavior is on by default and can be opted out via a new `opttest.DisablePulumiVersionLog()` option, mirroring the existing `DisableGrpcLog` opt-out convention
- Failures in either command are logged rather than propagated, so the diagnostic hook cannot break stack creation

## Test plan

- [x] `make lint` passes with zero issues
- [x] `make test` passes
- [x] New unit tests cover the option setter and the `Defaults()` reset

## Changes

### New files

- `pulumitest/versionLog.go` - `logPulumiVersionInfo` helper that runs `pulumi version` and `pulumi plugin ls -p` through the stack's `PulumiCommand` and writes the trimmed output to the test log

### Modified files

- `pulumitest/newStack.go` - Invoke `logPulumiVersionInfo` after the stack is assigned to `pt.currentStack`, gated on `!options.DisablePulumiVersionLog`
- `pulumitest/opttest/opttest.go` - Add `DisablePulumiVersionLog` field to `Options`, the matching `DisablePulumiVersionLog()` option constructor, and reset the field in `Defaults()`
- `pulumitest/opttest/opttest_test.go` - Add `TestDisablePulumiVersionLogOption` and `TestDefaultsResetsDisablePulumiVersionLog` to cover the new flag

Closes #161