### PR TITLE
ci: pin acceptance-test Pulumi CLI to 3.237.0

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v6
       with:
-        pulumi-version: dev
+        pulumi-version: 3.237.0
 
     - name: Setup Node
       uses: actions/setup-node@v4


### PR DESCRIPTION
The acceptance-test workflow installed the Pulumi CLI from the `dev` pre-release channel (`pulumi-version: dev`), so every run floated to the current tip of pulumi/pulumi master and acceptance-test results drifted from one day to the next, independently of the change under test.

Pin the install action to a fixed CLI version (`3.237.0`) so the suite runs against a stable, reproducible toolchain.

Part of #176
