### PR TITLE
ci: adopt gotestsum for better test error reporting

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -27,9 +27,13 @@ jobs:
         with:
           skip_dotnet_and_java: "true"
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.13.0
+
       - name: Run acceptance tests
         run: make test
         env:
+          GO_TEST_EXEC: "gotestsum --format github-actions --"
           PULUMITEST_TEMP_DIR: ${{ github.workspace }}/test_temp
           PULUMITEST_RETAIN_FILES_ON_FAILURE: "true"
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 MAKEFLAGS    := --warn-undefined-variables
 
+# Test runner. Defaults to plain `go test` for local runs; CI overrides this
+# with gotestsum to emit GitHub Actions annotations. Everything after `--` is
+# forwarded to `go test`, so the test flags below are unchanged either way.
+GO_TEST_EXEC ?= go test
+
 .PHONY: test
 test:
-	go test -v -coverprofile="coverage.txt" -coverpkg=./... ./...
+	$(GO_TEST_EXEC) -v -coverprofile="coverage.txt" -coverpkg=./... ./...


### PR DESCRIPTION
Adopt gotestsum so acceptance test failures surface as inline GitHub Actions annotations. CI sets `GO_TEST_EXEC` to `gotestsum --format github-actions --`; local `go test` is unchanged.