### PR TITLE
fix(pulumitest): isolate PULUMI_HOME per test

### DIFF
--- a/pulumitest/convert.go
+++ b/pulumitest/convert.go
@@ -40,6 +40,9 @@ func (pt *PulumiTest) Convert(t PT, language string, opts ...opttest.Option) Con
 	for _, opt := range opts {
 		opt.Apply(options)
 	}
+	if options.PulumiHome == "" {
+		options.PulumiHome = isolatedPulumiHome(t)
+	}
 
 	tempDir := tempDirWithoutCleanupOnFailedTest(t, "converted", options.TempDir)
 	base := filepath.Base(pt.workingDir)
@@ -52,6 +55,7 @@ func (pt *PulumiTest) Convert(t PT, language string, opts ...opttest.Option) Con
 	ptLogF(t, "converting to %s", language)
 	cmd := exec.Command("pulumi", "convert", "--language", language, "--generate-only", "--out", targetDir)
 	cmd.Dir = pt.workingDir
+	cmd.Env = withPulumiHome(options.PulumiHome)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		ptFatalF(t, "failed to convert directory: %s\n%s", err, out)

--- a/pulumitest/install.go
+++ b/pulumitest/install.go
@@ -11,6 +11,7 @@ func (pt *PulumiTest) Install(t PT) string {
 	t.Log("installing packages and plugins")
 	cmd := exec.Command("pulumi", "install")
 	cmd.Dir = pt.workingDir
+	cmd.Env = withPulumiHome(pt.options.PulumiHome)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		ptFatalF(t, "failed to install packages and plugins: %s\n%s", err, out)

--- a/pulumitest/newStack.go
+++ b/pulumitest/newStack.go
@@ -38,6 +38,11 @@ func (pt *PulumiTest) NewStack(t PT, stackName string, opts ...optnewstack.NewSt
 	// Set default stack opts. These can be overridden by the caller.
 	env := map[string]string{}
 
+	// Isolate Pulumi's on-disk schema cache per-test (see isolatedPulumiHome).
+	if options.PulumiHome != "" {
+		env["PULUMI_HOME"] = options.PulumiHome
+	}
+
 	if options.ConfigPassphrase != "" {
 		env["PULUMI_CONFIG_PASSPHRASE"] = options.ConfigPassphrase
 	}

--- a/pulumitest/opttest/opttest.go
+++ b/pulumitest/opttest/opttest.go
@@ -206,6 +206,10 @@ type Options struct {
 	ExtraWorkspaceOptions   []auto.LocalWorkspaceOption
 	DisableGrpcLog          bool
 	DisablePulumiVersionLog bool
+	// PulumiHome is the PULUMI_HOME to run pulumi commands against. It is set
+	// per-test by NewPulumiTest to isolate Pulumi's on-disk schema cache between
+	// parallel tests. Empty means use the ambient PULUMI_HOME.
+	PulumiHome string
 }
 
 // ProviderConfigUnion is a union type for specifying a provider configuration.

--- a/pulumitest/pulumiHome.go
+++ b/pulumitest/pulumiHome.go
@@ -1,0 +1,68 @@
+package pulumitest
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// isolatedPulumiHome returns a per-test PULUMI_HOME directory.
+//
+// Tests in a package run in parallel against the same PULUMI_HOME, so they share
+// Pulumi's on-disk schema cache (PULUMI_HOME/schemas). That cache is keyed by the
+// requested provider version, so an operation that resolves a provider to a
+// different version than the program declares (e.g. provider-upgrade testing) can
+// persist a schema under a mismatched key. A later test that reads it then fails
+// with "could not find package version information". Giving each test its own
+// PULUMI_HOME/schemas keeps that cache private so one test cannot poison another.
+// See pulumi/home#4816.
+//
+// The plugins directory is symlinked from the ambient PULUMI_HOME so plugin
+// binaries are not re-downloaded per test; only the schema cache is per-test.
+// (Pulumi's plugin discovery skips symlinked plugin *entries*, so we symlink the
+// whole plugins directory, which it follows transparently, rather than each
+// plugin.)
+func isolatedPulumiHome(t PT) string {
+	t.Helper()
+	home := filepath.Join(t.TempDir(), "pulumi-home")
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		ptFatalF(t, "failed to create isolated PULUMI_HOME: %v", err)
+	}
+	// Share plugin binaries and login/config from the ambient home so plugins
+	// aren't re-downloaded and ambient-backend consumers keep working. The
+	// schemas directory is deliberately NOT shared: it is the per-test cache that
+	// keeps schema entries from poisoning each other.
+	if ambient := ambientPulumiHome(); ambient != "" {
+		for _, entry := range []string{"plugins", "credentials.json", "config.json"} {
+			src := filepath.Join(ambient, entry)
+			if _, err := os.Lstat(src); err != nil {
+				continue // not present in the ambient home; nothing to share
+			}
+			if err := os.Symlink(src, filepath.Join(home, entry)); err != nil {
+				ptFatalF(t, "failed to share %q into isolated PULUMI_HOME: %v", entry, err)
+			}
+		}
+	}
+	return home
+}
+
+// withPulumiHome returns an environment for exec.Cmd that sets PULUMI_HOME to the
+// given directory. If home is empty it returns nil so the command inherits the
+// ambient environment unchanged.
+func withPulumiHome(home string) []string {
+	if home == "" {
+		return nil
+	}
+	return append(os.Environ(), "PULUMI_HOME="+home)
+}
+
+// ambientPulumiHome resolves the PULUMI_HOME that would be used without
+// isolation, so its plugin binaries can be shared.
+func ambientPulumiHome() string {
+	if h := os.Getenv("PULUMI_HOME"); h != "" {
+		return h
+	}
+	if h, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(h, ".pulumi")
+	}
+	return ""
+}

--- a/pulumitest/pulumiTest.go
+++ b/pulumitest/pulumiTest.go
@@ -34,6 +34,9 @@ func NewPulumiTest(t PT, source string, opts ...opttest.Option) *PulumiTest {
 	for _, opt := range opts {
 		opt.Apply(options)
 	}
+	if options.PulumiHome == "" {
+		options.PulumiHome = isolatedPulumiHome(t)
+	}
 	pt := &PulumiTest{
 		ctx:        ctx,
 		workingDir: source,

--- a/pulumitest/pulumiTest_test.go
+++ b/pulumitest/pulumiTest_test.go
@@ -93,7 +93,8 @@ func TestDefaults(t *testing.T) {
 	assert.Equal(t, "correct horse battery staple", env["PULUMI_CONFIG_PASSPHRASE"], "should configure passphrase for encryption")
 	assert.NotEmpty(t, env["PULUMI_BACKEND_URL"], "should configure backend URL")
 	assert.NotEmpty(t, env["PULUMI_DEBUG_GRPC"], "should configure gRPC debug log")
-	assert.Len(t, env, 3, "should not configure additional environment variables")
+	assert.NotEmpty(t, env["PULUMI_HOME"], "should isolate PULUMI_HOME per test")
+	assert.Len(t, env, 4, "should not configure additional environment variables")
 }
 
 func TestInPlace(t *testing.T) {
@@ -107,7 +108,8 @@ func TestInPlace(t *testing.T) {
 	assert.Equal(t, "correct horse battery staple", env["PULUMI_CONFIG_PASSPHRASE"], "should configure passphrase for encryption")
 	assert.NotEmpty(t, env["PULUMI_BACKEND_URL"], "should configure backend URL")
 	assert.NotEmpty(t, env["PULUMI_DEBUG_GRPC"], "should configure gRPC debug log")
-	assert.Len(t, env, 3, "should not configure additional environment variables")
+	assert.NotEmpty(t, env["PULUMI_HOME"], "should isolate PULUMI_HOME per test")
+	assert.Len(t, env, 4, "should not configure additional environment variables")
 }
 
 func TestSkipStackCreate(t *testing.T) {


### PR DESCRIPTION
Tests in a package run in parallel against the same `PULUMI_HOME`, so they share Pulumi's on-disk schema cache (`PULUMI_HOME/schemas`). That cache is keyed by the requested provider version. A test that resolves a provider to a different version than its program declares — e.g. the provider-upgrade tests, which keep a program pinned to one version but run it against an older baseline plugin binary — can persist a schema under a mismatched key (filename says one version, contents say another). A different test that later loads that version reads the mismatched entry and fails with `could not find package version information for pkg: <name>`, panicking in codegen. Because both the poisoning write and the reads race on the shared cache, the failure is order- and timing-dependent (it shows up reliably in CI, intermittently locally).

This gives each test its own `PULUMI_HOME` so the schema cache is private and one test can no longer poison another. Plugin binaries and login/config are shared from the ambient `PULUMI_HOME` via symlinks (`plugins/`, `credentials.json`, `config.json`), so plugins are not re-downloaded per test and ambient-backend usage keeps working; only `schemas/` is per-test.

Verified by running the convert tests against a `PULUMI_HOME` whose schema cache was already poisoned: they fail on `main` and pass with this change. The full `pulumitest` package is otherwise green. This removes the need for the interim CLI pin in #177.

Part of #176
