### PR TITLE
ci: un-pin acceptance-test Pulumi CLI

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v6
       with:
-        pulumi-version: 3.237.0
+        pulumi-version: latest
 
     - name: Setup Node
       uses: actions/setup-node@v4


### PR DESCRIPTION
#179 gave each test its own `PULUMI_HOME`, removing the shared schema-cache contention between parallel tests that the interim CLI pin (#177) worked around. This restores a floating CLI (`latest`) so the acceptance suite exercises current Pulumi again.

This PR's own acceptance-test run is the live check that the suite is green against an unpinned CLI.

Part of #176
